### PR TITLE
Force tag for older docker api

### DIFF
--- a/vars/dockerBuild.groovy
+++ b/vars/dockerBuild.groovy
@@ -30,6 +30,7 @@ def call(body) {
   def dockerfile = config.get('dockerfile', 'Dockerfile')
   def push = config.get('push', false)
   def cleanup = config.get('cleanup', false)
+  def forceTag = config.get('forcetag','')
   def buildArgs = ""
   config.get('args',[:]).each { arg, value ->
      buildArgs += "--build-arg ${arg}=${value} "
@@ -40,7 +41,7 @@ def call(body) {
   sh "docker build -t ${dockerRepo}:${tags[0]} -f ${dockerfile} ${buildArgs} ${buildDir}"
   if(tags.size() > 1) {
     tags.each { tag ->
-      sh "docker tag ${dockerRepo}:${tags[0]} ${dockerRepo}:${tag}"
+      sh "docker tag ${forceTag} ${dockerRepo}:${tags[0]} ${dockerRepo}:${tag}"
     }
   }
   if(push) {


### PR DESCRIPTION
## Problem

Older docker api requires `-f` flag for retagging images. Helper function should support adding `-f` tag. In future iterations, it would be need to auto-detect docker  version, and add `-f` tag automatically. 
 
## Solution

```
dockerBuild forcetag:true,
   .... //other parameters
```

