### PR TITLE
Add query operations to cloudformation step

### DIFF
--- a/test/cloudformationTestPipeline.groovy
+++ b/test/cloudformationTestPipeline.groovy
@@ -1,0 +1,146 @@
+@Library('ciinabox_toshke') _
+
+pipeline {
+  agent any
+  environment {
+    SOURCE_BUCKET = 'demo-source.ci.base2.services'
+    AWS_REGION = 'ap-southeast-2'
+  }
+  stages {
+    stage('prepare') {
+      steps {
+        script {
+          def rand = new Random().nextInt().toString(),
+              template = "testCloudFormationTemplate${rand}.yaml",
+          // simple cloud formation template outputs value of param1, and created EFS volume
+              templateContent = """
+AWSTemplateFormatVersion: "2010-09-09"
+Description: A sample template
+Parameters:
+  param1:
+    Type: String
+Outputs:
+  out1:
+    Value:
+      Ref: param1
+  efs:
+    Value:
+      Ref: MyEFS
+Resources:
+  MyEFS: 
+    Type: "AWS::EFS::FileSystem"
+"""
+          writeFile file: template, text: templateContent
+          //upload to s3
+          s3(file: template,
+                  bucket: env.SOURCE_BUCKET,
+                  prefix: 'pipeline_tests',
+                  region: env.AWS_REGION
+          )
+
+          //store template location to be used in subsequent stages
+          def templateLocation = "https://${env.SOURCE_BUCKET}.s3.amazonaws.com/pipeline_tests/${template}"
+          writeFile file: 'template_location.txt', text: templateLocation
+          stash name: 'template_location', include: 'template_location.txt'
+        }
+      }
+    }
+
+    stage('stack-create') {
+      steps {
+        script {
+          unstash 'template_location'
+          def templateLocation = readFile file: 'template_location.txt'
+          cloudformation(
+                  region: env.AWS_REGION,
+                  action: 'create',
+                  stackName: 'cloudormation-pipeline-test',
+                  templateUrl: templateLocation,
+                  parameters: [ param1: 'parameter_value' ]
+          )
+        }
+
+      }
+    }
+    stage('stack-query') {
+      steps {
+        script {
+          // query created cloudformation stack for output and element info
+          def outValue = cloudformation(
+                  region: env.AWS_REGION,
+                  stackName: 'cloudormation-pipeline-test',
+                  queryType: 'output',
+                  query: 'out1'
+          )
+          def efsInfo = cloudformation(
+                  region: env.AWS_REGION,
+                  stackName: 'cloudormation-pipeline-test',
+                  queryType: 'element',
+                  query: 'MyEFS'
+          ),
+              paramValue = 'parameter_value'
+
+          echo "Stack has created EFS with resource id ${efsInfo.PhysicalResourceId}"
+          echo "Stack has created with param value ${outValue}"
+          if (!"${outValue}".equals("${paramValue}")) {
+            throw new GroovyRuntimeException("Stack output = ${outValue} does not match ${paramValue}")
+          }
+        }
+
+      }
+    }
+    stage('stack-update') {
+      steps {
+        script {
+          // update stack parameter, and query output
+          // test equality between the two
+          def paramValue = new Random().nextInt().toString()
+          cloudformation(
+                  region: env.AWS_REGION,
+                  action: 'update',
+                  stackName: 'cloudormation-pipeline-test',
+                  parameters: [ param1: paramValue ]
+          )
+          def outValue = cloudformation(
+                  region: env.AWS_REGION,
+                  stackName: 'cloudormation-pipeline-test',
+                  queryType: 'output',
+                  query: 'out1'
+          )
+          if (!"${outValue}".equals("${paramValue}")) {
+            throw new GroovyRuntimeException("Stack output = ${outValue} does not match ${paramValue}")
+          }
+        }
+      }
+    }
+
+    stage('stack-update-query') {
+      steps {
+        script {
+          // testing stack action and query in same step
+          def paramValue = new Random().nextInt().toString()
+          def outValue = cloudformation(
+                  region: env.AWS_REGION,
+                  action: 'update',
+                  stackName: 'cloudormation-pipeline-test',
+                  parameters: [ param1: paramValue ],
+                  queryType: 'output',
+                  query: 'out1'
+          )
+          if (!"${outValue}".equals("${paramValue}")) {
+            throw new GroovyRuntimeException("Stack output = ${outValue} does not match ${paramValue}")
+          }
+        }
+      }
+    }
+  }
+  post {
+    always {
+      cloudformation(
+              region: env.AWS_REGION,
+              action: 'delete',
+              stackName: 'cloudormation-pipeline-test'
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Bug fix

`cloudformation action:delete` is fixed and tested

## Query cloudformation stack

Rather than just management actions for cloudformation step, this step should allow querying existing cloudformation stacks (and their substacks), as well as stack outputs. Consumer selects type of query by passing `queryType` parameter. 

### Query outputs

```
stage('query){
     steps {
         script {
              def outValue = cloudformation(stackName: 'ciinabox', 
                   queryType: 'output',
                   query: 'CiinaboxBinaryVersion'
                   region: 'ap-southeast-2')
              echo "Deployed ciinabox v${outValue}"
         } 
     }
}
```

### Query elements

Query element should allow querying substack elements, recursively, dot `.` seperated

```
stage('query){
     steps {
         script {
              def jenkins = cloudformation(stackName: 'ciinabox', 
                   queryType: 'element',
                   query: 'ECSServicesStack.jenkinsStack.JenkinsService'
                   region: 'ap-southeast-2')
              echo "Jenkins service : ${jenkins.PhysicalResourceId}"
         } 
     }
}
```

## Testing

This PR tries to introduce standard contract for testing pipeline steps. Pipeline steps should have appropriate `test/${stepName}TestPipeline.groovy` test pipeline. This pipeline should not have external dependencies, and sensible defaults for pipeline parameters should be provided. 

Included is test pipeline for cloudformation step, making sure no regression is introduced by extending `cloudformation` step. 

