### PR TITLE
route53 step

### DIFF
--- a/src/com/base2/ciinabox/AwsHelper.groovy
+++ b/src/com/base2/ciinabox/AwsHelper.groovy
@@ -1,5 +1,12 @@
 package com.base2.ciinabox
 
+
+import com.amazonaws.auth.*
+import com.amazonaws.regions.*
+import com.amazonaws.waiters.*
+import com.amazonaws.services.securitytoken.*
+import com.amazonaws.services.securitytoken.model.*
+
 /**
  * Return AWS Region from Instance Metadata
  */
@@ -15,5 +22,6 @@ def accountId() {
   def region = awsRegion()
   shellOut("aws sts get-caller-identity --region ${region} --query Account --output text")
 }
+
 
 

--- a/vars/cloudformation.groovy
+++ b/vars/cloudformation.groovy
@@ -21,9 +21,9 @@ cloudformation
 If you omit the templateUrl then for updates it will use the existing template
 
 ************************************/
-@Grab(group='com.amazonaws', module='aws-java-sdk-cloudformation', version='1.11.198')
-@Grab(group='com.amazonaws', module='aws-java-sdk-iam', version='1.11.226')
-@Grab(group='com.amazonaws', module='aws-java-sdk-sts', version='1.11.226')
+@Grab(group='com.amazonaws', module='aws-java-sdk-cloudformation', version='1.11.359')
+@Grab(group='com.amazonaws', module='aws-java-sdk-iam', version='1.11.359')
+@Grab(group='com.amazonaws', module='aws-java-sdk-sts', version='1.11.359')
 
 import com.amazonaws.auth.*
 import com.amazonaws.regions.*

--- a/vars/route53.groovy
+++ b/vars/route53.groovy
@@ -1,0 +1,188 @@
+/***********************************
+ route53 DSL
+
+ manage AWS Route 53 records
+
+ example usage
+ route53(
+ action: 'propagateNs'
+ srcZone: 'app1.subdomain.example.com'
+ dstZone: 'example.com',
+ srcZoneAccount: '123456789012',
+ srcZoneRole: 'MyRoute53AccessRoleInParentZoneOptionalParam',
+ srcZoneRoleExternalId: 'optional-external-id-for-route53-zone-role',
+ srcRegion: 'us-east-1' # defaults to us-east-1
+ dstZoneAccount: '123456789012',
+ dstZoneRole: 'MyRoute53AccessRoleInParentZoneOptionalParam',
+ dstZoneRoleExternalId: 'optional-external-id-for-route53-zone-role',
+ dstRegion: 'us-east-1  # defaults to us-east-1,
+ TTL: 300 # defaults to 5 minutes
+ )
+ ************************************/
+
+@Grab(group = 'com.amazonaws', module = 'aws-java-sdk-route53', version = '1.11.359')
+@Grab(group = 'com.amazonaws', module = 'aws-java-sdk-iam', version = '1.11.359')
+@Grab(group = 'com.amazonaws', module = 'aws-java-sdk-sts', version = '1.11.359')
+
+
+import com.amazonaws.services.securitytoken.*
+import com.amazonaws.services.securitytoken.model.*
+import com.amazonaws.auth.*
+import com.amazonaws.services.route53.*
+import com.amazonaws.services.route53.model.*
+
+def call(body) {
+  def config = body
+  def action = config.action
+  if (config?.srcRegion == null){
+    config.srcRegion = 'us-east-1'
+  }
+  if (config?.dstRegion == null){
+    config.dstRegion = 'us-east-1'
+  }
+  echo "route53: Executing action ${action} with config: ${config}"
+  switch (action) {
+    case 'propagateNs':
+      echo "propagate"
+      createRecordsInParentZone(config)
+      return true
+      break
+    default:
+      error "Route53 step does not support action '${action}'"
+      return false
+  }
+  return false
+}
+
+@NonCPS
+def createRecordsInParentZone(config) {
+  script {
+    def srcCredentials = awsCredsProvider(accountId: config?.srcZoneAccount,
+            region: config?.srcRegion,
+            role: config?.srcZoneRole,
+            externalId: config?.srcZoneRoleExternalId
+    )
+    def dstCredentials = awsCredsProvider(accountId: config?.dstZoneAccount,
+            region: config?.dstRegion,
+            role: config?.dstZoneRole,
+            externalId: config?.dstZoneRoleExternalId
+    )
+    def srcClientBuilder = AmazonRoute53ClientBuilder.standard()
+            .withRegion(config?.srcRegion),
+        dstClientBuilder = AmazonRoute53ClientBuilder.standard()
+                .withRegion(config?.dstRegion)
+
+
+
+    if (srcCredentials != null) srcClientBuilder = srcClientBuilder.withCredentials(srcCredentials)
+    if (dstCredentials != null) dstClientBuilder = dstClientBuilder.withCredentials(dstCredentials)
+
+
+    def srcClient = srcClientBuilder.build(),
+        dstClient = dstClientBuilder.build()
+
+
+    def srcZone = getZoneByName(srcClient, config.srcZone),
+        dstZone = getZoneByName(dstClient, config.dstZone)
+
+    if (srcZone == null) {
+      error "Couldn't find source hosted zone ${config.srcZone}"
+    }
+
+    if (dstZone == null) {
+      error "Couldn't find destination hosted zone ${config.dstZone}"
+    }
+
+    echo "Using ${srcZone.id}"
+
+    def nsRecord = getNsRecord(srcClient, srcZone.id)
+    nsRecord.setTTL(config?.TTL != null ? config.TTL : 300)
+
+    println "Source record set to be delegated: ${nsRecord}"
+    println "Delegation zone Id: ${dstZone.id}"
+
+    def delegateRequest = new ChangeResourceRecordSetsRequest()
+            .withHostedZoneId(dstZone.id.replace('/hostedzone/',''))
+            .withChangeBatch(new ChangeBatch([
+            new Change(
+                    ChangeAction.UPSERT,
+                    nsRecord
+            )
+    ]))
+
+    dstClient.changeResourceRecordSets(delegateRequest)
+
+  }
+
+}
+
+@NonCPS
+def getNsRecord(r53client, zoneId) {
+  def recordSets = r53client.listResourceRecordSets(new ListResourceRecordSetsRequest()
+          .withHostedZoneId(zoneId.replace('/hostedzone/',''))
+  ).resourceRecordSets
+
+  for (int i = 0; i < recordSets.size(); i++) {
+    if (recordSets[i].type == 'NS') {
+      return recordSets[i]
+    }
+  }
+}
+
+
+@NonCPS
+def getZoneByName(r53client, zoneName) {
+  def zones = r53client.listHostedZonesByName(new ListHostedZonesByNameRequest()
+          .withDNSName(zoneName)
+  ).getHostedZones()
+  if (zones.size() > 0) {
+    return zones[0]
+  }
+  return null
+}
+
+@NonCPS
+def awsCredsProvider(body) {
+  def config = body
+  if (config?.role != null && config?.accountId != null) {
+    return new AWSStaticCredentialsProvider(
+            getCredentials(config.accountId, config.role, config?.region, config?.externalId)
+    )
+  } else {
+    return InstanceProfileCredentialsProvider.instance
+  }
+
+}
+
+
+@NonCPS
+def getCredentials(awsAccountId, roleName, region, roleExternalId) {
+  println "Assuming role"
+  def stsCreds = assumeRole(awsAccountId, region, roleName, roleExternalId)
+  return new BasicSessionCredentials(
+          stsCreds.getAccessKeyId(),
+          stsCreds.getSecretAccessKey(),
+          stsCreds.getSessionToken()
+  )
+
+}
+
+@NonCPS
+def assumeRole(awsAccountId, region, roleName, roleExternalId) {
+  def roleArn = "arn:aws:iam::${awsAccountId}:role/${roleName}"
+  def roleSessionName = "ciinabox-pipelines-${awsAccountId}"
+  println "assuming IAM role ${roleArn}"
+  def sts = new AWSSecurityTokenServiceClient()
+  if (!region.equals("us-east-1")) {
+    sts.setEndpoint("sts.${region}.amazonaws.com")
+  }
+  def assumeRoleRequest = new AssumeRoleRequest()
+          .withRoleArn(roleArn).withDurationSeconds(3600)
+          .withRoleSessionName(roleSessionName)
+  if (roleExternalId != null) {
+    assumeRoleRequest = assumeRoleRequest.withExternalId(roleExternalId)
+  }
+  def assumeRoleResult = sts.assumeRole(assumeRoleRequest)
+  return assumeRoleResult.getCredentials()
+}
+


### PR DESCRIPTION
## Intro

Route53 step should allow for propagation of route53 records from child to parent zone. Both zones can be in different AWS Accounts where jenkins is running, and accessed through assumed role. 

## Usage

```
route53(
  action: 'propagateNs'
  srcZone: 'app1.subdomain.example.com'
  dstZone: 'example.com',
  srcZoneAccount: '123456789012',
  srcZoneRole: 'MyRoute53AccessRoleInParentZoneOptionalParam',
  srcZoneRoleExternalId: 'optional-external-id-for-route53-zone-role',
  dstZoneAccount: '123456789012',
  dstZoneRole: 'MyRoute53AccessRoleInParentZoneOptionalParam',
  dstZoneRoleExternalId: 'optional-external-id-for-route53-zone-role',
  TTL: 300 # defaults to 5 minutes
 )
```

## Testing pipeline

```
@Library('ciinabox') _

pipeline {
    
    agent any
    
    stages {
        
        stage('propagate-route53-zone'){
            steps {
                route53 action:'propagateNs',
                    srcZone: 'pipelinestest.aws.example.com',
                    dstZone: 'aws.example.com',
                    srcZoneRole: 'testPipelinesSourceRole',
                    srcZoneAccount: 123456789012,
                    srcZoneRoleExternalId:'srcexternalid',
                    dstZoneRole: 'testPipelinesDestionationRole',
                    dstZoneAccount: 123456789012
            }
        }
    }
}
```

## Updates

Updated grabs in cloudformation step, and grabs in route53 steps, to latest aws-sdk artifact version. 

