### PR TITLE
Bake without cookbook

### DIFF
--- a/vars/bakeAMI.groovy
+++ b/vars/bakeAMI.groovy
@@ -43,6 +43,7 @@ def call(body) {
   bakeEnv << "SOURCE_BUCKET=${config.sourceBucket}"
   bakeEnv << "CB_BUILD_NO=${config.cookbookVersion}"
   bakeEnv << "BUCKET_REGION=${config.bucketRegion}"
+  bakeEnv << "LOCAL_COOKBOOKS=${config.get('localCookbooks',true)}"
 
   def role = config.get('role').toUpperCase()
 
@@ -56,9 +57,13 @@ def call(body) {
     bakeEnv << "BRANCH=${branchName}"
     withEnv(bakeEnv) {
       sh './configure $CIINABOX_NAME $REGION $AMI_USERS'
-      unstash 'cookbook'
+      if(env.LOCAL_COOKBOOKS) {
+        unstash 'cookbook'
+        sh 'tar xvfz cookbooks.tar.gz'
+      } else {
+        sh 'mkdir -p cookbooks'
+      }
       sh '''
-      tar xvfz cookbooks.tar.gz
       mkdir -p data_bags
       mkdir -p environments
       mkdir -p encrypted_data_bag_secret

--- a/vars/bakeAMI.groovy
+++ b/vars/bakeAMI.groovy
@@ -37,6 +37,7 @@ def call(body) {
   bakeEnv << "GIT_COMMIT=${shortCommit}"
   bakeEnv << "SSH_USERNAME=${config.get('sshUsername', '')}"
   config.amiName = config.get('baseAMI')
+  config.amiBranch = config.get('baseAMIBranch')
 
   // Windows chef env vars
   bakeEnv << "CHEF_PATH=${config.chefPath}"

--- a/vars/bakeAMI.groovy
+++ b/vars/bakeAMI.groovy
@@ -57,7 +57,7 @@ def call(body) {
     bakeEnv << "BRANCH=${branchName}"
     withEnv(bakeEnv) {
       sh './configure $CIINABOX_NAME $REGION $AMI_USERS'
-      if(env.LOCAL_COOKBOOKS) {
+      if(config.get('localCookbooks',true)) {
         unstash 'cookbook'
         sh 'tar xvfz cookbooks.tar.gz'
       } else {


### PR DESCRIPTION
I made these changes to allow for AMI baking as part of a app pipeline and didn't want to have to clone the chef cookbook repo since it was being downloaded from S3.

I should behave as before unless it's configured with `localCookbooks: false`