### PR TITLE
CloudFormation step - validate end state

### DIFF
--- a/vars/cloudformation.groovy
+++ b/vars/cloudformation.groovy
@@ -243,8 +243,17 @@ def wait(cf, stackName, successStatus)   {
           echo "We seem to be timing out ${ex}...ignoring"
       }
     }
-    println "Stack: ${stackName} success - ${successStatus}"
-    return true
+    // confirm that end state equals requested state,
+    // as sdk waiters will exit not only on success, but also on failure
+    // states. e.g. UPDATE_ROLLBACK_COMPLETE for UPDATE_COMPLETE
+    DescribeStacksResult result = cf.describeStacks(new DescribeStacksRequest().withStackName(stackName))
+    currentState = result.getStacks().get(0).getStackStatus()
+    def success = currentState.toString().equals(successStatus.toString())
+    println "Stack ${stackName} end state: ${currentState}"
+    println "Stack ${stackName} required state: ${successStatus}"
+    println ">>>> ${success ? 'SUCCESS' : 'FAILURE'}"
+
+    return success
    } catch(Exception e) {
      println "Stack: ${stackName} failed - ${e}"
      return false


### PR DESCRIPTION
## Bug fix

Cloudformation create/update/delete operation would not report failure, as long as the operation is completed. Default java aws-sdk waiter behaviour do not report on operation success, it only reports if operation completed or not. 

This pull request adds check wether operation was success, by comparing actual end state of CloudFormation stack with desired state 
- `UPDATE_COMPLETE` for update operation
- `CREATE_COMPLETE` for create operation
- ` DELETE_COMPLETE` for delete operation

Test pipeline has been modified to include testing stage for the failure reporting, conditionally executed based on `TEST_FOR_FAILURE` parameter value. 
