### PR TITLE
filters out any the amis without any matching branches if any are found

### DIFF
--- a/vars/bakeAMI.groovy
+++ b/vars/bakeAMI.groovy
@@ -37,6 +37,7 @@ def call(body) {
   bakeEnv << "GIT_COMMIT=${shortCommit}"
   bakeEnv << "SSH_USERNAME=${config.get('sshUsername', '')}"
   config.amiName = config.get('baseAMI')
+  config.amiBranch = config.get('baseAMIBranch')
 
   // Windows chef env vars
   bakeEnv << "CHEF_PATH=${config.chefPath}"


### PR DESCRIPTION
Adds support for providing an new config item called `baseAMIBranch` for bakeAMI and `amiBranch` for lookupAMI which filters AMI with BranchName tags. If no AMI with a given branch name is found it will return the latest `master` branch tag.