### PR TITLE
sam package and deploy using the cli

### DIFF
--- a/vars/samDeploy.groovy
+++ b/vars/samDeploy.groovy
@@ -1,0 +1,48 @@
+/***********************************
+ samDeploy DSL
+
+ Packages sam template and pushes artefacts to S3
+
+ example usage
+ samDeploy(
+   region: env.AWS_REGION,
+   stackName: dev,
+   template: template.yaml,
+   source_bucket: source.bucket,
+   prefix: cloudformation/${PROJECT}/${BRANCH_NAME}/${BUILD_NUMBER},
+   uploadToS3: true||false, #if the template is too large the file has to be re-uploaded to s3. Requires PutObject permissions from the assumed account to the source bucket
+   parameters: [
+     'ENVIRONMENT_NAME' : 'dev',
+   ],
+   accountId: '1234567890', #the aws account Id you want the stack operation performed in
+   role: 'myrole' # the role to assume from the account the pipeline is running from
+ )
+ ************************************/
+
+def call(body) {
+  def config = body
+  def compiled_template = config.template.replace(".yaml", "-compiled.yaml")
+
+  println("Copying s3://${config.source_bucket}/${config.prefix}/${compiled_template} to local")
+
+  sh "aws s3 cp s3://${config.source_bucket}/${config.prefix}/${compiled_template} ${compiled_template}"
+
+  def options = "--template-file ${compiled_template} --stack-name ${config.stackName} --capabilities CAPABILITY_IAM --region ${config.region}"
+
+  if (config.parameters != null || !config.parameters.empty) {
+    options = options.concat(" --parameter-overrides")
+    config.parameters.each {
+      options = options.concat(" ${it.key}=${it.value}")
+    }
+  }
+
+  if (config.uploadToS3 != null && config.uploadToS3) {
+    options = options.concat(" --s3-bucket ${config.source_bucket} --s3-prefix ${config.prefix}")
+  }
+
+  println("deploying ${compiled_template} to environment ${config.environment}")
+
+  withIAMRole(config.accountId,config.region,config.role) {
+    sh "aws cloudformation deploy ${options}"
+  }
+}

--- a/vars/samPackage.groovy
+++ b/vars/samPackage.groovy
@@ -1,0 +1,34 @@
+/***********************************
+ samPackage DSL
+
+ Packages sam template and pushes artefacts to S3
+
+ example usage
+ samPackage(
+   region: env.AWS_REGION,
+   template: template.yaml,
+   source_bucket: source.bucket,
+   prefix: cloudformation/${PROJECT}/${BRANCH_NAME}/${BUILD_NUMBER}
+ )
+ ************************************/
+
+def call(body) {
+  def config = body
+
+  def compiled_template = config.template.replace(".yaml", "-compiled.yaml")
+
+  println "Compiling SAM template"
+
+  sh """
+  #!/bin/bash
+  aws cloudformation package \
+    --template-file ${config.template} \
+    --s3-bucket ${config.source_bucket} \
+    --s3-prefix ${config.prefix} \
+    --output-template-file ${compiled_template}
+  """
+
+  println("Copying ${compiled_template} to s3://${config.source_bucket}/${config.prefix}")
+
+  sh "aws s3 cp ${compiled_template} s3://${config.source_bucket}/${config.prefix}/${compiled_template}"
+}


### PR DESCRIPTION
aws cli commands cloudformation package and deploy have a lot of functionality built into these commands and it would take some time to rewrite this in groovy as it is using change sets. Probably something that would be useful for other single stacks but for another day. 

The only limitation these commands is it requires a local template file, as in you cannot provide a s3 location. If the local file is too big a s3 location must be provided so it can upload it to s3. Which means the assumed account requires `s3:putObject` permission to the source bucket. Issue has been raise in cli repo https://github.com/aws/aws-cli/issues/3643

Sample package and deploy steps

```
    stage('Compile cloudformation') {
      steps {
        script {
          env['SHORT_COMMIT'] = env.GIT_COMMIT.substring(0,7)
          if(env.BRANCH_NAME == 'master') {
            env['cf_version'] = "${env.SHORT_COMMIT}-${env.BUILD_NUMBER}"
          } else {
            env['cf_version'] = env.BRANCH_NAME
          }
        }
        samPackage(
         region: env.AWS_REGION,
         template: 'template.yaml',
         source_bucket: env.SOURCE_BUCKET,
         prefix: "cloudformation/${env.PROJECT_NAME}/${cf_version}"
       )
      }
    }

    stage('Deploy stack dev') {
      steps {
        samDeploy(
          region: env.AWS_REGION,
          stackName: 'dev-sam-demo',
          template: 'template.yaml',
          source_bucket: env.SOURCE_BUCKET,
          prefix: "cloudformation/${env.PROJECT_NAME}/${cf_version}",
          parameters: [
            'Environment' : 'dev',
          ],
          accountId: env.DEV_ACCOUNT_ID,
          role: 'ciinabox'
        )
      }
    }
```