### PR TITLE
adding support for saving stack ssm params on deletion and restoring on create

### DIFF
--- a/vars/lookupSnapshot.groovy
+++ b/vars/lookupSnapshot.groovy
@@ -1,0 +1,120 @@
+/***********************************
+lookupSnapshot DSL
+
+lookup up RDS/Redshift/ESB snapshots
+
+example usage
+  lookupSnapshot(
+    type: 'redshift',
+    accountId: env.DEV_ACCOUNT,
+    region: env.REGION,
+    role: env.ROLE,
+    resource: 'my-redshift-cluster',
+    snapshotType: 'manual',
+    snapshot: 'latest',
+    envVarName: 'REDSHIFT_SNAPSHOT_ID'
+  )
+
+************************************/
+@Grab(group='com.amazonaws', module='aws-java-sdk-iam', version='1.11.466')
+@Grab(group='com.amazonaws', module='aws-java-sdk-sts', version='1.11.466')
+@Grab(group='com.amazonaws', module='aws-java-sdk-ssm', version='1.11.466')
+@Grab(group='com.amazonaws', module='aws-java-sdk-redshift', version='1.11.466')
+
+import com.amazonaws.auth.*
+import com.amazonaws.regions.*
+import com.amazonaws.services.securitytoken.*
+import com.amazonaws.services.securitytoken.model.*
+import com.amazonaws.services.redshift.*
+import com.amazonaws.services.redshift.model.*
+
+
+def call(body) {
+  def config = body
+
+  if(!(config.type)){
+    throw new GroovyRuntimeException("type must be specified")
+  }
+
+  if(config.type.toLowerCase() == 'redshift'){
+    handleRedshift(config)
+  } else {
+    throw new GroovyRuntimeException("type ${config.type} currently not supported")
+  }
+
+}
+
+
+@NonCPS
+def setupRedshiftClient(region, awsAccountId = null, role =  null) {
+  def cb = AmazonRedshiftClientBuilder.standard().withRegion(region)
+  def creds = getCredentials(awsAccountId, region, role)
+  if(creds != null) {
+    cb.withCredentials(new AWSStaticCredentialsProvider(creds))
+  }
+  return cb.build()
+}
+
+@NonCPS
+def getCredentials(awsAccountId, region, roleName) {
+  if(env['AWS_SESSION_TOKEN'] != null) {
+    return new BasicSessionCredentials(
+      env['AWS_ACCESS_KEY_ID'],
+      env['AWS_SECRET_ACCESS_KEY'],
+      env['AWS_SESSION_TOKEN']
+    )
+  } else if(awsAccountId != null && roleName != null) {
+    def stsCreds = assumeRole(awsAccountId, region, roleName)
+    return new BasicSessionCredentials(
+      stsCreds.getAccessKeyId(),
+      stsCreds.getSecretAccessKey(),
+      stsCreds.getSessionToken()
+    )
+  } else {
+    return null
+  }
+}
+
+@NonCPS
+def assumeRole(awsAccountId, region, roleName) {
+  def roleArn = "arn:aws:iam::" + awsAccountId + ":role/" + roleName
+  def roleSessionName = "sts-session-" + awsAccountId
+  println "assuming IAM role ${roleArn}"
+  def sts = new AWSSecurityTokenServiceClient()
+  if (!region.equals("us-east-1")) {
+      sts.setEndpoint("sts." + region + ".amazonaws.com")
+  }
+  def assumeRoleResult = sts.assumeRole(new AssumeRoleRequest()
+            .withRoleArn(roleArn).withDurationSeconds(3600)
+            .withRoleSessionName(roleSessionName))
+  return assumeRoleResult.getCredentials()
+}
+
+@NonCPS
+def handleRedshift(config) {
+  def redshift = setupRedshiftClient(config.region, config.accountId, config.role)
+
+  def outputName = config.get('envVarName', 'SNAPSHOT_ID')
+  def snapshot = config.get('snapshot', 'latest')
+
+  def request = new DescribeClusterSnapshotsRequest()
+    .withClusterIdentifier(config.resource)
+    .withSortingEntities(new SnapshotSortingEntity()
+      .withAttribute(SnapshotAttributeToSortBy.CREATE_TIME)
+      .withSortOrder(SortByOrder.DESC)
+    )
+
+  if(config.snapshotType) {
+    request.setSnapshotType(config.snapshotType)
+  } 
+  def snapshots = redshift.describeClusterSnapshots(request)
+  if(snapshot.toLowerCase() == 'latest') {
+    if(snapshots.getSnapshots().size() > 0) {
+      env[outputName] = snapshots.getSnapshots().get(0).getSnapshotIdentifier()
+      env["${outputName}_OWNER"] = snapshots.getSnapshots().get(0).getOwnerAccount()
+      env["${outputName}_CLUSTER_ID"] = snapshots.getSnapshots().get(0).getClusterIdentifier()
+    }
+  } else {
+    throw new GroovyRuntimeException("current only snapshot 'latest' is supported")
+  }
+}

--- a/vars/ssmParameter.groovy
+++ b/vars/ssmParameter.groovy
@@ -1,0 +1,119 @@
+/***********************************
+ssmParameter DSL
+
+puts an ssm parameter
+
+example usage
+
+
+************************************/
+@Grab(group='com.amazonaws', module='aws-java-sdk-iam', version='1.11.466')
+@Grab(group='com.amazonaws', module='aws-java-sdk-sts', version='1.11.466')
+@Grab(group='com.amazonaws', module='aws-java-sdk-ssm', version='1.11.466')
+@Grab(group='com.amazonaws', module='aws-java-sdk-redshift', version='1.11.466')
+
+import com.amazonaws.auth.*
+import com.amazonaws.regions.*
+import com.amazonaws.services.securitytoken.*
+import com.amazonaws.services.securitytoken.model.*
+import com.amazonaws.services.simplesystemsmanagement.*
+import com.amazonaws.services.simplesystemsmanagement.model.*
+
+
+def call(body) {
+  def config = body
+  def ssm = setupSSMClient(config.region, config.accountId, config.role)
+
+  if(!(config.action)){
+    throw new GroovyRuntimeException("action get/put must be specified")
+  }  
+
+  if(!(config.parameter)){
+    throw new GroovyRuntimeException("parameter must be specified")
+  }
+
+  if(config.action.toLowerCase() == 'put') {
+    if(!(config.value)){
+      throw new GroovyRuntimeException("value must be specified")
+    }
+    def paramType = config.get('type', 'String')
+    def result = ssm.putParameter(new PutParameterRequest()
+      .withName(config.parameter)
+      .withType(paramType)
+      .withValue(config.value)
+      .withOverwrite(true)
+    )
+    println "put param ${config.parameter}"
+  } else if(config.action.toLowerCase() == 'get') {
+    return getSSMParams(ssm, config.parameter)
+  }
+
+}
+
+@NonCPS
+def setupSSMClient(region, awsAccountId = null, role =  null) {
+  def cb = AWSSimpleSystemsManagementClientBuilder.standard().withRegion(region)
+  def creds = getCredentials(awsAccountId, region, role)
+  if(creds != null) {
+    cb.withCredentials(new AWSStaticCredentialsProvider(creds))
+  }
+  return cb.build()
+}
+
+@NonCPS
+def getCredentials(awsAccountId, region, roleName) {
+  if(env['AWS_SESSION_TOKEN'] != null) {
+    return new BasicSessionCredentials(
+      env['AWS_ACCESS_KEY_ID'],
+      env['AWS_SECRET_ACCESS_KEY'],
+      env['AWS_SESSION_TOKEN']
+    )
+  } else if(awsAccountId != null && roleName != null) {
+    def stsCreds = assumeRole(awsAccountId, region, roleName)
+    return new BasicSessionCredentials(
+      stsCreds.getAccessKeyId(),
+      stsCreds.getSecretAccessKey(),
+      stsCreds.getSessionToken()
+    )
+  } else {
+    return null
+  }
+}
+
+@NonCPS
+def assumeRole(awsAccountId, region, roleName) {
+  def roleArn = "arn:aws:iam::" + awsAccountId + ":role/" + roleName
+  def roleSessionName = "sts-session-" + awsAccountId
+  println "assuming IAM role ${roleArn}"
+  def sts = new AWSSecurityTokenServiceClient()
+  if (!region.equals("us-east-1")) {
+      sts.setEndpoint("sts." + region + ".amazonaws.com")
+  }
+  def assumeRoleResult = sts.assumeRole(new AssumeRoleRequest()
+            .withRoleArn(roleArn).withDurationSeconds(3600)
+            .withRoleSessionName(roleSessionName))
+  return assumeRoleResult.getCredentials()
+}
+
+@NonCPS
+def getSSMParams(ssm, path) {
+  def ssmParams = []
+  def result = ssm.getParametersByPath(new GetParametersByPathRequest()
+    .withPath(path)
+    .withRecursive(false)
+    .withWithDecryption(true)
+    .withMaxResults(10)
+  )
+  ssmParams += result.parameters
+  while(result.nextToken != null) {
+    result = ssm.getParametersByPath(new GetParametersByPathRequest()
+        .withPath(path)
+        .withRecursive(false)
+        .withWithDecryption(true)
+        .withMaxResults(10)
+        .withNextToken(result.nextToken)
+    )
+    ssmParams += result.parameters
+  }
+  return ssmParams
+}


### PR DESCRIPTION
### create usage
```groovy
          cloudformation(
                  region: env.AWS_REGION,
                  action: 'create',
                  stackName: 'test',
                  stackState: '/mystacks'
          )
```
Basically this will try and load any parameters from the ssm path `/mystacks/test/parameters` and then load them from `/mystacks/parameters` and only add parameters that didn't exist under the stack path.  

If you don't supply a templateUrl in the create it will look for a parameter `/mystacks/test/CfTemplateUrl` and then  `/mystacks/CfTemplateUrl` is that doesn't exist

### delete usage

```groovy
        cloudformation(
                region: env.AWS_REGION,
                action: 'delete',
                stackName: 'test',
                stackState: '/mystacks'
        )
```

This will save all the current stack parameters to the ssm path `/mystacks/test/parameters` also if the stack has a `CfTemplateUrl` output parameter it will store that  in `/mystacks/test/CfTemplateUrl`