### PR TITLE
print cloudformation errors on failure

### DIFF
--- a/vars/cloudformation.groovy
+++ b/vars/cloudformation.groovy
@@ -96,7 +96,7 @@ def handleActionRequest(cf, config){
     break
   }
   if(!success) {
-    printFailedStackEvents(cf, config.stackName)
+    printFailedStackEvents(cf, config.stackName, config.region)
     throw new Exception("Stack ${config.stackName} failed to ${config.action}")
   }
 }
@@ -479,7 +479,7 @@ def getStackEvents(cf, stackName) {
  }
 
 @NonCPS
-def printStackEvent(StackEvent event, stackName) {
+def printStackEvent(StackEvent event, stackName, region) {
   final StringBuilder text = new StringBuilder(128)
 
   def reason = event.getResourceStatusReason()
@@ -490,31 +490,41 @@ def printStackEvent(StackEvent event, stackName) {
       text.append("\nSTACK: ${stackName}")
       text.append("\nSTATUS: ${event.getResourceStatus()}")
       text.append("\nERROR: ${event.getResourceStatusReason()}")
+      text.append("\nEVENT: ${getEventUrl(region,event.getStackId())}")
     }
   }
   println text
 }
 
+// Grabs all events for a stack and prints details of each failed resource
+// including error message and link to event in web console
 @NonCPS
-def printFailedStackEvents(cf, stackName) {
+def printFailedStackEvents(cf, stackName, region) {
+  // grab all events
   def events = getStackEvents(cf,stackName)
-
-   events.each { event ->
+  events.each { event ->
     def eventStatus = event.getResourceStatus()
     if (eventStatus.matches("CREATE_FAILED|ROLLBACK_IN_PROGRESS|UPDATE_FAILED|DELETE_FAILED")) {
-
-       if (event.getResourceType() == "AWS::CloudFormation::Stack") {
+      // If resource is a nested stack look through nested stack
+      if (event.getResourceType() == "AWS::CloudFormation::Stack") {
         def nestStackName = event.getPhysicalResourceId()
         def nestedEvents = getStackEvents(cf,nestStackName)
         nestedEvents.each { nestedEvent ->
           def nestedEventStatus = nestedEvent.getResourceStatus()
           if (nestedEventStatus.matches("CREATE_FAILED|ROLLBACK_IN_PROGRESS|UPDATE_FAILED|DELETE_FAILED")) {
-            printStackEvent(nestedEvent,nestStackName)
+            printStackEvent(nestedEvent,nestStackName,region)
           }
         }
       } else {
-        printStackEvent(event,stackName)
+        printStackEvent(event,stackName,region)
       }
     }
   }
+}
+
+// Generates the event url for the event in the cloudformation dashboard
+@NonCPS
+def getEventUrl(region,stackId) {
+  def encodedStackId = java.net.URLEncoder.encode(stackId, "UTF-8")
+  return "https://${region}.console.aws.amazon.com/cloudformation/home?region=${region}#/stacks/${encodedStackId}/events"
 }


### PR DESCRIPTION
Prints cloudformation errors on create/update/delete failures.
If a nested stack contains an error it will search that stack and report the error. Will only search 1 level deep.

### Example Output
```text
TIME: Thu Jan 10 05:22:00 GMT 2019
TYPE: AWS::CloudFormation::Stack
STACK: arn:aws:cloudformation:ap-southeast-2:857301260320:stack/dev-web/9e33c180-1497-11e9-ab02-0ae3f52010f8
STATUS: ROLLBACK_IN_PROGRESS
ERROR: The following resource(s) failed to create: [webservice]. . Rollback requested by user.

TIME: Thu Jan 10 05:22:00 GMT 2019
TYPE: AWS::CloudFormation::Stack
STACK: arn:aws:cloudformation:us-east-1:111111111111:stack/dev-web/9e33c180-1497-11e9-ab02-0ae3f52010f8
STATUS: CREATE_FAILED
ERROR: Embedded stack arn:aws:cloudformation:us-east-1:111111111111:stack/dev-web-webservice-1B88E8VFUYRSZ/a170eb20-1497-11e9-9ee6-0ae74239a372 was not successfully created: Parameter validation failed: parameter value vpc-b6fba0d32457ds for parameter name VPCId does not exist

TIME: Thu Jan 10 05:21:51 GMT 2019
TYPE: AWS::CloudFormation::Stack
STACK: arn:aws:cloudformation:us-east-1:111111111111:stack/dev-web-webservice-1B88E8VFUYRSZ/a170eb20-1497-11e9-9ee6-0ae74239a372
STATUS: CREATE_FAILED
ERROR: Parameter validation failed: parameter value vpc-b6fba0d32457ds for parameter name VPCId does not exist
```