### PR TITLE
Fix: ensure that bakery sees empty values for positional parameters w…

### DIFF
--- a/vars/bakeAMI.groovy
+++ b/vars/bakeAMI.groovy
@@ -94,7 +94,7 @@ def call(body) {
       echo "Baking AMI: ${ROLE}"
       echo "AMI Build NO: ${AMI_BUILD_ID}"
       echo "==================================================="
-      ./bakery $CLIENT $ROLE $PACKER_TEMPLATE $PACKER_DEFAULT_PARAMS $AMI_BUILD_ID $SOURCE_AMI $AMI_BUILD_ID $GIT_COMMIT $CHEF_RUN_LIST $PACKER_INSTANCE_TYPE $BAKE_VOLUME_SIZE
+      ./bakery "${CLIENT}" "${ROLE}" "${PACKER_TEMPLATE}" "${PACKER_DEFAULT_PARAMS}" "${AMI_BUILD_ID}" "${SOURCE_AMI}" "${AMI_BUILD_ID}" "${GIT_COMMIT}" "${CHEF_RUN_LIST}" "${PACKER_INSTANCE_TYPE}" "${BAKE_VOLUME_SIZE}"
       if [ $? != 0 ]; then
         echo "ERROR: Packer Baking failed"
         exit 1


### PR DESCRIPTION
**Summary:**
Ensure that bakery sees empty values for positional parameters with null value, otherwise bakery will incorrectly process the positions of these input parameters

**Problem:**
Currently, if one of the arguments passed into bakery in bakeAMI is null, bakery will then misinterpret the position of the arguments and assign the argument to the wrong variable.
_EG.
 (where $CLIENT = null and ROLE = 'test_role')
`./bakery $CLIENT $ROLE `
will be seen by bakery as 
`./bakery 'test_role'`
meaning bakery will assign $1 as 'test_role' and $2 as null, incorrectly_


**Solution:**
 By wrapping the parameters in quotes, any null values will be interpreted as empty strings, which will maintain bakery's expected positions of parameters