### PR TITLE
Cfn max error retry

### DIFF
--- a/vars/cloudformation.groovy
+++ b/vars/cloudformation.groovy
@@ -49,6 +49,8 @@ import com.amazonaws.services.simplesystemsmanagement.model.*
 import com.amazonaws.waiters.*
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.retry.RetryPolicy
+import com.amazonaws.retry.PredefinedRetryPolicies.SDKDefaultRetryCondition
+import com.amazonaws.retry.PredefinedBackoffStrategies.SDKDefaultBackoffStrategy
 import org.yaml.snakeyaml.Yaml
 import groovy.json.JsonSlurperClassic
 import java.util.concurrent.*
@@ -369,9 +371,10 @@ def doesStackExist(cf, stackName) {
 }
 
 @NonCPS
-def setupCfClient(region, awsAccountId = null, role =  null, maxErrorRetry = 10) {
+def setupCfClient(region, awsAccountId = null, role =  null, maxErrorRetry=10) {
   ClientConfiguration clientConfiguration = new ClientConfiguration()
-  clientConfiguration.withRetryPolicy(new RetryPolicy(null, null, maxErrorRetry, true))
+  maxErrorRetry = (maxErrorRetry == null)? 10 : maxErrorRetry
+  clientConfiguration.withRetryPolicy(new RetryPolicy(new SDKDefaultRetryCondition(), new SDKDefaultBackoffStrategy(), maxErrorRetry, true))
   
   def cb = AmazonCloudFormationClientBuilder.standard()
     .withRegion(region)

--- a/vars/cloudformation.groovy
+++ b/vars/cloudformation.groovy
@@ -371,11 +371,11 @@ def doesStackExist(cf, stackName) {
 @NonCPS
 def setupCfClient(region, awsAccountId = null, role =  null, maxErrorRetry = 10) {
   ClientConfiguration clientConfiguration = new ClientConfiguration()
-  configuration.withRetryPolicy(new RetryPolicy(null, null, maxErrorRetry, true))
+  clientConfiguration.withRetryPolicy(new RetryPolicy(null, null, maxErrorRetry, true))
   
   def cb = AmazonCloudFormationClientBuilder.standard()
     .withRegion(region)
-    .withClientConfiguration(configuration)
+    .withClientConfiguration(clientConfiguration)
   def creds = getCredentials(awsAccountId, region, role)
   if(creds != null) {
     cb.withCredentials(new AWSStaticCredentialsProvider(creds))

--- a/vars/cloudformation.groovy
+++ b/vars/cloudformation.groovy
@@ -369,12 +369,9 @@ def doesStackExist(cf, stackName) {
 }
 
 @NonCPS
-def setupCfClient(region, awsAccountId = null, role =  null, maxErrorRetry = DEFAULT_MAX_ERROR_RETRY) {
+def setupCfClient(region, awsAccountId = null, role =  null, maxErrorRetry = 10) {
   ClientConfiguration clientConfiguration = new ClientConfiguration()
-  configuration.withRetryPolicy(new RetryPolicy(new CustomRetryCondition(),
-            DEFAULT_BACKOFF_STRATEGY,
-            maxErrorRetry,
-            false))
+  configuration.withRetryPolicy(new RetryPolicy(null, null, maxErrorRetry, true))
   
   def cb = AmazonCloudFormationClientBuilder.standard()
     .withRegion(region)


### PR DESCRIPTION
Add retry policy for cloudformation api calls.
Use SDKDefaultRetryCondition and SDKDefaultBackoffStrategy with default max retries of 10