### PR TITLE
new features for AMI based methods

### DIFF
--- a/src/com/base2/ciinabox/aws/Util.groovy
+++ b/src/com/base2/ciinabox/aws/Util.groovy
@@ -1,0 +1,32 @@
+package com.base2.ciinabox.aws
+
+import com.amazonaws.regions.Regions
+import com.amazonaws.regions.Region
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
+import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest
+
+class Util implements Serializable {
+  
+  /**
+   * Return AWS Region for the current region if on EC2 other wise will return sydney
+   */
+  static def getRegion() {
+    def region = Regions.getCurrentRegion()
+    if (region == null) {
+      region = Region.getRegion(Regions.AP_SOUTHEAST_2)
+    }
+    return region.getName()
+  }
+
+  /**
+   * Return AWS Account ID gathered from default credentials
+   * @return
+   */
+   static def getAccountId() {
+     def sts = AWSSecurityTokenServiceClientBuilder.standard()
+       .withRegion(getRegion())
+       .build()
+     return sts.getCallerIdentity(new GetCallerIdentityRequest()).account
+   }
+  
+}


### PR DESCRIPTION
### library

#### com.base2.ciinabox.aws.Util
- add new helper methods to lookup current region and account id

### methods

#### lookupAMI
- look up from ssm parameter

#### packer
- refactor ami ssm lookup to use lookupAMI method
- set env vars for the ami name and the bake id

#### verifyAMIv2
- support ami lookup to allow testing before baking ami
- add `runlist` parameter to run recipe during test
- accept chef license
- destroy instance at the end of the run