### PR TITLE
start and stop a selenium hub in fargate

### DIFF
--- a/src/com/base2/ciinabox/EcsTaskRunner.groovy
+++ b/src/com/base2/ciinabox/EcsTaskRunner.groovy
@@ -1,0 +1,196 @@
+package com.base2.ciinabox
+
+import com.amazonaws.services.ecs.AmazonECSClient
+import com.amazonaws.services.ecs.model.RegisterTaskDefinitionRequest
+import com.amazonaws.services.ecs.model.DescribeTasksRequest
+import com.amazonaws.services.ecs.model.ContainerDefinition
+import com.amazonaws.services.ecs.model.PortMapping
+import com.amazonaws.services.ecs.model.KeyValuePair
+import com.amazonaws.services.ecs.model.Tag
+import com.amazonaws.services.ecs.model.NetworkMode
+import com.amazonaws.services.ecs.model.Compatibility
+import com.amazonaws.services.ecs.model.RunTaskRequest
+import com.amazonaws.services.ecs.model.AwsVpcConfiguration
+import com.amazonaws.services.ecs.model.NetworkConfiguration
+import com.amazonaws.services.ecs.model.DeregisterTaskDefinitionRequest
+import com.amazonaws.services.ecs.model.StopTaskRequest
+import com.amazonaws.services.ecs.model.LaunchType
+
+import com.amazonaws.waiters.NoOpWaiterHandler
+import com.amazonaws.waiters.WaiterParameters
+import java.util.concurrent.Future
+
+class EcsTaskRunner implements Serializable {
+  
+  def name
+  def id
+  def client
+  
+  EcsTaskRunner(String name, AmazonECSClient client) {
+    this.name = name
+    this.client = client
+    this.id = name + '-' + UUID.randomUUID().toString()
+  }
+  
+  /**
+  
+  **/
+  def startTask(Map config, ArrayList taskDefinitions) {
+    def containerDefinitions = createContainerDefinitions(taskDefinitions)
+    
+    def tags = []
+    tags << new Tag().withKey('CreatedBy').withValue('ciinabox-pipelines')
+    tags << new Tag().withKey('Task').withValue(this.name)
+    
+    client.registerTaskDefinition(new RegisterTaskDefinitionRequest()
+      .withContainerDefinitions(containerDefinitions)
+      .withCpu(config.cpu)
+      .withMemory(config.memory)
+      .withExecutionRoleArn(config.executionRole)
+      .withFamily(id)
+      .withNetworkMode(NetworkMode.Awsvpc)
+      .withRequiresCompatibilities(Compatibility.FARGATE)
+      .withTags(tags)
+    )
+    
+    def awsVpcConfiguration = new AwsVpcConfiguration()
+      .withSubnets([config.subnet])
+      .withSecurityGroups([config.securityGroup])
+      
+    def networkConfiguration = new NetworkConfiguration()
+      .withAwsvpcConfiguration(awsVpcConfiguration)
+    
+    def taskRequest = new RunTaskRequest()
+      .withCluster(config.cluster)
+      .withTaskDefinition(id)
+      .withLaunchType(LaunchType.FARGATE)
+      .withNetworkConfiguration(networkConfiguration)
+      .withStartedBy('ciinabox-pipelines')
+
+    def runResult = client.runTask(taskRequest)
+    def taskArn = runResult.tasks.first().taskArn
+    println "Started task ${taskArn} in ${config.cluster} ECS cluster"
+    
+    waitTillRunning(taskArn, config.cluster)
+    
+    return taskArn
+  }
+  
+  /**
+  
+  **/
+  def stopTask(Map config) {
+    def taskDefinition = getTaskDefinition(config.taskArn, config.cluster)
+    
+    def stopTaskRequest = new StopTaskRequest()
+      .withCluster(config.cluster)
+      .withReason('stopped by jenkins')
+      .withTask(config.taskArn)
+    
+    println "Stopping ${config.taskArn} in ${config.cluster} ECS cluster"
+    client.stopTask(stopTaskRequest)
+    
+    println "Cleaning up task defintion ${taskDefinition}"
+    deregisterTaskDefinition(taskDefinition)
+  }
+  
+  /**
+  
+  **/
+  def createContainerDefinitions(ArrayList taskDefinitions) {
+    def containerDefinitions = []
+    
+    taskDefinitions.each { td ->
+      def cd = new ContainerDefinition()
+        .withName(td.name)
+        .withImage(td.image)
+        .withEssential(true)
+      
+      if (td.ports) {
+        def portMappings = []
+        
+        td.ports.each {
+          portMappings << new PortMapping().withContainerPort(it.container).withHostPort(it.host)
+        }
+        cd.withPortMappings(portMappings)
+      }
+      
+      if (td.environment) {
+        def envVars = []
+        td.environment.each {
+          envVars << new KeyValuePair().withName(it.key).withValue(it.value)
+        }
+        cd.withEnvironment(envVars)
+      }
+      
+      containerDefinitions << cd
+    }
+    
+    return containerDefinitions
+  }
+  
+  /**
+  
+  **/
+  def waitTillRunning(String taskArn, String cluster) {
+    def waiter = client.waiters().tasksRunning()
+    
+    def describeTasksRequest = new DescribeTasksRequest()
+      .withCluster(cluster)
+      .withTasks([taskArn])
+    
+    Future future = waiter.runAsync(
+      new WaiterParameters<>(describeTasksRequest),
+      new NoOpWaiterHandler()
+    )
+    
+    while(!future.isDone()) {
+      try {
+        println "waiting for task ${taskArn} to reach the RUNNING state"
+        Thread.sleep(5 * 1000)
+      } catch(InterruptedException ex) {
+        println "We seem to be timing out ${ex}...ignoring"
+      }
+    }
+  }
+  
+  /**
+  
+  **/
+  def getEndpoint(String taskArn, String cluster) {
+    def request = new DescribeTasksRequest()
+      .withTasks([taskArn])
+      .withCluster(cluster)
+      
+    def response = client.describeTasks(request)
+
+    def task = response.getTasks().first()
+    def attachment = task.getAttachments().first()
+    def details = attachment.getDetails()
+    def ip = details.findResult { it.getName() == "privateIPv4Address" ? it.getValue() : null }
+    
+    return ip
+  }
+  
+  /**
+  
+  **/
+  def getTaskDefinition(String taskArn, String cluster) {
+    def request = new DescribeTasksRequest()
+      .withTasks([taskArn])
+      .withCluster(cluster)
+    def response = client.describeTasks(request)
+    def task = response.getTasks().first()
+    
+    return task.getTaskDefinitionArn()
+  }
+  
+  /**
+  
+  **/
+  def deregisterTaskDefinition(String taskDefinition) {
+    def deregisterTaskDefinitionRequest = new DeregisterTaskDefinitionRequest()
+      .withTaskDefinition(taskDefinition)
+    client.deregisterTaskDefinition(deregisterTaskDefinitionRequest)
+  }
+}

--- a/src/com/base2/ciinabox/GetEcsContainerDetails.groovy
+++ b/src/com/base2/ciinabox/GetEcsContainerDetails.groovy
@@ -1,0 +1,41 @@
+package com.base2.ciinabox
+
+import groovy.json.JsonSlurper
+
+import com.amazonaws.services.ecs.model.DescribeTaskDefinitionRequest
+import com.amazonaws.services.ecs.AmazonECSClientBuilder
+
+class GetEcsContainerDetails implements Serializable {
+  
+  private static cluster
+  private static taskArn
+  private static taskDefName
+  private static taskDefVersion
+  private static taskDefintion
+  
+  GetEcsContainerDetails(String region) {
+    def jsonSlurper = new JsonSlurper()
+    def uri = System.getenv("ECS_CONTAINER_METADATA_URI")
+    def resp = uri.toURL().text
+    def doc = jsonSlurper.parseText(resp)
+    cluster = doc["Labels"]["com.amazonaws.ecs.cluster"]
+    taskArn = doc["Labels"]["com.amazonaws.ecs.task-arn"]
+    taskDefName = doc["Labels"]["com.amazonaws.ecs.task-definition-family"]
+    taskDefVersion = doc["Labels"]["com.amazonaws.ecs.task-definition-version"]
+    
+    def ecs = AmazonECSClientBuilder.standard().withRegion(region).build()
+    def response = ecs.describeTaskDefinition(new DescribeTaskDefinitionRequest()
+                    .withTaskDefinition("${taskDefName}:${taskDefVersion}"))
+    
+    taskDefintion = response.getTaskDefinition()
+  }
+  
+  def cluster() {
+    return this.cluster
+  }
+  
+  def executionRole() {
+    return this.taskDefintion.getExecutionRoleArn()
+  }
+  
+}

--- a/vars/startSelenium.groovy
+++ b/vars/startSelenium.groovy
@@ -1,0 +1,95 @@
+/***********************************
+startSelenium DSL
+
+starts a selenium hub on fargate
+
+example usage
+
+startSelenium(
+  nodes: ['chrome','firefox','opera'], // (optional, defaults to chrome and firefox nodes)
+  version: '3', // (optional, defaults to 3)
+  region: 'us-east-1', // (optional, defaults to look up the current region)
+  subnet: 'subnet-123456789', // (optional, defaults to look up the current subnet)
+  securityGroup: 'sg-123456789', // (optional, defaults to look up the current security group)
+  executionRole: 'arn:aws:iam:accountid::role/executionRole', // (optional, defaults to look up the current executionRole)
+  cluster: 'my-cluster', // (optional, defaults to look up the current ecs cluster)
+  cpu: '512', // (optional, defaults to 512)
+  memory: '1024', // (optional, defaults to 1024)
+)
+
+
+************************************/
+
+import com.base2.ciinabox.aws.AwsClientBuilder
+import com.base2.ciinabox.InstanceMetadata
+import com.base2.ciinabox.GetInstanceDetails
+import com.base2.ciinabox.GetEcsContainerDetails
+import com.base2.ciinabox.EcsTaskRunner
+
+def call(body=[:]) {
+  def config = body
+  def details = [:]
+  
+  def metadata = new InstanceMetadata()
+  // if the node is a ec2 instance using the ec2 plugin
+  def instanceId = env.NODE_NAME.find(/i-[a-zA-Z0-9]*/)
+    
+  if (!instanceId) {
+    instanceId = metadata.instanceId()
+  }
+  
+  def region = config.get('region', metadata.region())
+  
+  def instance = new GetInstanceDetails(region, instanceId)
+  details.subnet = config.get('subnet', instance.subnet())
+  details.securityGroup = config.get('securityGroup', instance.securityGroup())
+  
+  def task = new GetEcsContainerDetails(region)
+  details.executionRole = config.get('executionRole', task.executionRole())
+  details.cluster = config.get('cluster', task.cluster())
+  
+  details.cpu = config.get('cpu', '512')
+  details.memory = config.get('memory', '1024')
+
+  def allowedNodes = ['chrome','firefox','opera']
+  def version = config.get('version', '3')
+  
+  def taskDef = []
+  taskDef << [
+    name: 'selenium-hub',
+    image: "selenium/hub:${version}",
+    ports: [[container: 4444, host: 4444]],
+  ]
+  
+  def nodes = config.get('nodes',['chrome','firefox'])
+  def nodePort = 5555
+  
+  nodes.eachWithIndex { node, index ->
+    if (allowedNodes.contains(node)) {
+      nodePort += index
+      
+      taskDef << [
+        name: node,
+        image: "selenium/node-${node}:${version}",
+        environment: [
+          [key: 'HUB_HOST', value: 'localhost'],
+          [key: 'HUB_PORT', value: '4444'],
+          [key: 'START_XVFB', value: 'false'],
+          [key: 'SE_OPTS', value: "-port ${nodePort}"]
+        ]
+      ]
+    } else {
+      echo "WARNING: ${node} is not a known selenium node. Must be one of ${allowedNodes}"
+    }
+  }
+  
+  def client = new AwsClientBuilder([region: region]).ecs()
+  def runner = new EcsTaskRunner('selenium', client)
+  def taskArn = runner.startTask(details, taskDef)
+  def endpoint = runner.getEndpoint(taskArn, details.cluster)
+  
+  env['SELENIUM_ENDPOINT'] = endpoint
+  env['SELENIUM_PORT'] = '4444'
+  env['SELENIUM_SOCKET'] = "${endpoint}:4444"
+  env['SELENIUM_TASK'] = taskArn
+}

--- a/vars/stopSelenium.groovy
+++ b/vars/stopSelenium.groovy
@@ -1,0 +1,42 @@
+/***********************************
+stopSelenium DSL
+
+stops selenium hub on fargate
+
+example usage
+
+stopSelenium(
+  region: 'us-east-1', //(optional, defaults to lookup current region)
+  cluster: 'my-cluster', //(optional, defaults to lookup current ecs cluster)
+  taskArn: 'arn:aws:ecs:us-east-1:123456789:task/my-cluster/id' //(optional, defaults to the SELENIUM_TASK environment set by the startSelenium() method)
+)
+
+************************************/
+
+import com.base2.ciinabox.aws.AwsClientBuilder
+import com.base2.ciinabox.InstanceMetadata
+import com.base2.ciinabox.GetEcsContainerDetails
+import com.base2.ciinabox.EcsTaskRunner
+
+def call(body=[:]) {
+  def config = body
+  def details = [:]
+  
+  def metadata = new InstanceMetadata()  
+  def region = config.get('region', metadata.region())
+  
+  def task = new GetEcsContainerDetails(region)
+  details.cluster = config.get('cluster', task.cluster())
+  
+  def envTaskArn = env.getAt('SELENIUM_TASK')
+  details.taskArn = config.get('taskArn', envTaskArn)
+  
+  if (!details.taskArn) {
+    println "WARNING: no taskArn found, unable to clean up."
+    return
+  }
+  
+  def client = new AwsClientBuilder([region: region]).ecs()
+  def runner = new EcsTaskRunner('selenium', client)
+  runner.stopTask(details)
+}


### PR DESCRIPTION
## What

2 new methods and new library

### startSelenium() 
- starts a selenium hub on fargate and retrieves the endpoint and exposes it through environment variables

```sh
SELENIUM_ENDPOINT -> ip address of fargate task
SELENIUM_PORT -> port of fargate task (4444)
SELENIUM_SOCKET -> ip:port
SELENIUM_TASK -> task arn exposed for cleanup
```

- containers are default selenium containers and defaults to version 3 
- default nodes of chrome and firefox
- all defaults overridable 

### stopSelenium() 
- stops the selenium fargate task and cleans up the task definition

### EcsTaskRunner
- orchestration of the starting and stopping of the fargate task and registration and deregistration of the task definition
- built to support different short term build tasks to run on fargate 