### PR TITLE
pipeline seeder ignore missing job or groovy files

### DIFF
--- a/vars/pipelineSeeder.groovy
+++ b/vars/pipelineSeeder.groovy
@@ -39,12 +39,14 @@ def call(body) {
             jobDsl scriptText: libraryResource('seeder.groovy'),
               removedConfigFilesAction: 'DELETE', 
               removedJobAction: 'DELETE', 
-              removedViewAction: 'DELETE'
+              removedViewAction: 'DELETE',
+              ignoreMissingFiles: true
 
             jobDsl targets: 'pipelines/**/*.job',
               removedConfigFilesAction: 'DELETE', 
               removedJobAction: 'DELETE', 
-              removedViewAction: 'DELETE'
+              removedViewAction: 'DELETE',
+              ignoreMissingFiles: true
           }
         }
       }


### PR DESCRIPTION
The pipeline fails if either .job or .groovy files are missing from the pipelines directory. This PR will ignore those failures.