### PR TITLE
Not using us-east-1 for S3 getBucketLocation

### DIFF
--- a/vars/cloudformation.groovy
+++ b/vars/cloudformation.groovy
@@ -539,8 +539,14 @@ def waitUntilComplete(cf, stackName) {
 def getTemplateParameterNames(config){
   def newTemplateParams = [],
     s3location = s3bucketKeyFromUrl(config.templateUrl),
-    s3headClient = setupS3Client(config.region),
+
+    // https://github.com/aws/aws-sdk-java/issues/1451#issuecomment-358742502
+    // https://github.com/aws/aws-sdk-java/issues/1338
+    // never using us-east-1 for getBucketLocation or it will yield weird `The authorization header is malformed`
+    s3headClient = setupS3Client((config.region == "us-east-1")? "us-east-2" : config.region),
     newTemplate = null
+
+
 
     def headBucketRegion = s3headClient.getBucketLocation(s3location.bucket)
     if(headBucketRegion == '' || headBucketRegion == 'US'){


### PR DESCRIPTION
This is more of a cry for help than actual a proper PR. 

It seems like one _cannot_ use `us-east-1` to find the location of a bucket outside that region. 
What happens is that my bucket is on `us-west-2`; I know need to create certain stacks in `us-east-1`. 

Turns out that attempting to run `s3headClient.getBucketLocation` with region `us-east-1` in a bucket in `us-west-2` simply doesn't work. Any other region works. 

I'm unsure how to address that? 

cc @aaronwalker  / @Guslington 