### PR TITLE
Bug fixes for networking lookups when Jenkins controller is running in Fargate

### DIFF
--- a/src/com/base2/ciinabox/InstanceMetadata.groovy
+++ b/src/com/base2/ciinabox/InstanceMetadata.groovy
@@ -1,31 +1,50 @@
 package com.base2.ciinabox
 
 import groovy.json.JsonSlurper
+import java.net.SocketException
 
 class InstanceMetadata implements Serializable {
   
-  private static doc
+  private static String region
+  private static String az
+  private static String accountId
+  private static String instanceId
+  private static boolean isEc2
   
   InstanceMetadata() {
     def jsonSlurper = new JsonSlurper()
-    def resp = "http://169.254.169.254/latest/dynamic/instance-identity/document".toURL().text
-    this.doc = jsonSlurper.parseText(resp)
+
+    try {
+      def resp = "http://169.254.169.254/latest/dynamic/instance-identity/document".toURL().text
+      this.isEc2 = true
+      def doc = jsonSlurper.parseText(resp)
+      this.region = doc.region
+      this.az = doc.availabilityZone[-1]
+      this.accountId = doc.accountId
+      this.instanceId = doc.instanceId
+    } catch (SocketException ex) {
+      this.isEc2 = false
+    }
+  }
+
+  def isEc2() {
+    return this.isEc2
   }
   
-  def region() {
-    return this.doc.region
+  def getRegion() {
+    return this.region
   }
   
-  def az() {
-    return this.doc.availabilityZone[-1]
+  def getAz() {
+    return this.az
   }
   
-  def accountId() {
-    return this.doc.accountId
+  def getAccountId() {
+    return this.accountId
   }
   
-  def instanceId() {
-    return this.doc.instanceId
+  def getInstanceId() {
+    return this.instanceId
   }
   
 }

--- a/src/com/base2/ciinabox/aws/Util.groovy
+++ b/src/com/base2/ciinabox/aws/Util.groovy
@@ -1,7 +1,9 @@
 package com.base2.ciinabox.aws
 
-import com.amazonaws.regions.Regions
-import com.amazonaws.regions.Region
+import com.amazonaws.regions.AwsRegionProviderChain
+import com.amazonaws.regions.AwsEnvVarOverrideRegionProvider
+import com.amazonaws.regions.InstanceMetadataRegionProvider
+import com.amazonaws.SdkClientException
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
 import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest
 
@@ -9,18 +11,22 @@ class Util implements Serializable {
   
   /**
    * Return AWS Region for the current region if on EC2 other wise will return sydney
+   * @return aws region string
    */
   static def getRegion() {
-    def region = Regions.getCurrentRegion()
-    if (region == null) {
-      region = Region.getRegion(Regions.AP_SOUTHEAST_2)
+    def region = null
+    try {
+      def chain = new AwsRegionProviderChain(new InstanceMetadataRegionProvider(), new AwsEnvVarOverrideRegionProvider())
+      region = chain.getRegion()
+    } catch (SdkClientException ex) {
+      println ex.getMessage()
     }
-    return region.getName()
+    return region
   }
 
   /**
    * Return AWS Account ID gathered from default credentials
-   * @return
+   * @return aws account id string
    */
    static def getAccountId() {
      def sts = AWSSecurityTokenServiceClientBuilder.standard()

--- a/vars/packer.groovy
+++ b/vars/packer.groovy
@@ -210,7 +210,3 @@ def writeScript(path) {
   def fileName = path.split('/').last()
   writeFile(file: fileName, text: content)
 }
-
-def lookupNetworkDetails(region) {
-  
-}

--- a/vars/packer.groovy
+++ b/vars/packer.groovy
@@ -45,8 +45,10 @@ def call(body) {
   if(!config.role) {
     throw new GroovyRuntimeException("(role: 'my-build') must be supplied")
   }
+
+  def platformType = config.get('type', 'linux')
   
-  if (config.type.startsWith('windows')) {
+  if (platformType.startsWith('windows')) {
     if (!config.cookbookS3Bucket && !config.cookbookS3Path) {
       throw new GroovyRuntimeException("(cookbookS3Bucket: 'source.cookbooks', cookbookS3Path: 'chef/0.1.0/cookbooks.tar.gz') must be supplied when using type: 'windows'")
     }
@@ -131,10 +133,11 @@ def call(body) {
 | Instance Profile: ${instanceProfile}
 | Source AMI: ${sourceAMI}
 | Instance Type: ${instanceType}
+| PlatformType: ${platformType}
 =================================================
   """)
   
-  def ptb = new PackerTemplateBuilder(config.role, config.get('type', 'linux'))
+  def ptb = new PackerTemplateBuilder(config.role, platformType)
   ptb.builder.region = region
   ptb.builder.source_ami = sourceAMI
   ptb.builder.instance_type = instanceType

--- a/vars/packer.groovy
+++ b/vars/packer.groovy
@@ -81,6 +81,7 @@ def call(body) {
 
     // if node name is not an instance id, try getting the instance id from the instance metadata
     if (!instanceId) {
+      println "retrieving the instance metadata"
       def metadata = new InstanceMetadata()
       if (!metadata.isEc2) {
         throw new GroovyRuntimeException("unable to lookup networking details, try specifing (vpcId: subnet: securityGroup: instanceProfile:) in your method")
@@ -96,15 +97,15 @@ def call(body) {
     }
 
     if (!subnet) {
-      vpcId = instance.subnet()
+      subnet = instance.subnet()
     }
 
     if (!securityGroup) {
-      vpcId = instance.securityGroup()
+      securityGroup = instance.securityGroup()
     }
 
     if (!instanceProfile) {
-      vpcId = instance.instanceProfile()
+      instanceProfile = instance.instanceProfile()
     }    
   }
   

--- a/vars/stopSelenium.groovy
+++ b/vars/stopSelenium.groovy
@@ -14,16 +14,19 @@ stopSelenium(
 ************************************/
 
 import com.base2.ciinabox.aws.AwsClientBuilder
-import com.base2.ciinabox.InstanceMetadata
 import com.base2.ciinabox.GetEcsContainerDetails
 import com.base2.ciinabox.EcsTaskRunner
+import com.base2.ciinabox.aws.Util
 
 def call(body=[:]) {
   def config = body
   def details = [:]
   
-  def metadata = new InstanceMetadata()  
-  def region = config.get('region', metadata.region())
+  // get the local region if not set by the method
+  def region = config.get('region', Util.getRegion())
+  if (!region) {
+    throw new GroovyRuntimeException("no AWS region found")
+  }
   
   def task = new GetEcsContainerDetails(region)
   details.cluster = config.get('cluster', task.cluster())


### PR DESCRIPTION
### Improvements
- dont perform metadata and ec2 instance lookups if defaults are set
- refactor region lookup to use the region provider chain to support region lookup in fargate
- return better errors if networking details cannot be looked up
- apply fixes to packer, verifyAmiV2 and selenium methods
- make chef run in packer optional