### PR TITLE
Timeout to allow force-deploy of empty changesets

### DIFF
--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -37,8 +37,9 @@ def call(body) {
         input message: 'Do you want to continue deploying despite an empty change-set?', ok: 'Yes'
         apply(config, stackNameUpper)
       }
-    } catch {
+    } catch (Exception timeout) {
           echo "Aborted due to time-out (empty change-set)"
+          return false
     }
     } else {
       apply(config, stackNameUpper)

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -32,11 +32,18 @@ def call(body) {
   def stackNameUpper = config.stackName.toUpperCase().replaceAll("-", "_")
 
   if (env["${stackNameUpper}_NO_EXECUTE_CHANGESET"] == 'TRUE') {
-    echo("Skipping execution changeset as no changes have been detected ...")
-  } else {
-    apply(config, stackNameUpper)
+    try {
+      timeout(time: 1, unit: "MINUTES") {
+        input message: 'Do you want to continue deploying despite an empty change-set?', ok: 'Yes'
+        apply(config, stackNameUpper)
+      }
+    } catch {
+          echo "Aborted due to time-out (empty change-set)"
+    }
+    } else {
+      apply(config, stackNameUpper)
+    }
   }
-}
 
 def apply(config, stackNameUpper) {
   

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -34,11 +34,11 @@ def call(body) {
   if (env["${stackNameUpper}_NO_EXECUTE_CHANGESET"] == 'TRUE') {
     try {
       timeout(time: 1, unit: "MINUTES") {
-        input message: 'Do you want to continue deploying despite an empty change-set?', ok: 'Yes'
+        input message: 'Deploy empty changeset?', ok: 'Yes'
         apply(config, stackNameUpper)
       }
     } catch (Exception timeout) {
-          echo "Aborted due to time-out (empty change-set)"
+          echo "Aborted due to time-out."
           return false
     }
     } else {


### PR DESCRIPTION
Encountered a scenario where certain changes weren't picked up as changes by cloudformation and no changeset was generated, blocking a deployment... adding a timeout so that user can force a deployment for minor changes (where a change-set won't be created)

"To update an AWS CloudFormation stack, you must submit template or parameter value changes to AWS CloudFormation. However, AWS CloudFormation won't recognize some template changes as an update, such as changes to a deletion policy, update policy, condition declaration, or output declaration. If you need to make such changes without making any other change, you can add or modify a metadata attribute for any of your resources."