### PR TITLE
Inspector - fix static resource names when multiple runs happen at the same time

### DIFF
--- a/resources/Inspector.yaml
+++ b/resources/Inspector.yaml
@@ -18,6 +18,10 @@ Parameters:
   subnetId:
       Type: String
       Description: The subnet ID for the temporary instance
+  stackName:
+      Type: String
+      Description: The name of the stach wiht UUID to append to resource names
+
 
 
 Conditions:
@@ -32,7 +36,8 @@ Resources:
     Properties:
       ManagedPolicyArns:
           - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
-      RoleName: testinstancerole
+      RoleName:
+          Fn::Sub: "testinstancerole${stackName}"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -48,8 +53,9 @@ Resources:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Roles:
-          - testInstanceRole
-    DependsOn: testInstanceRole
+          - Fn::Sub: "testinstancerole${stackName}"
+    DependsOn:
+        Fn::Sub: "testinstancerole${stackName}"
 
 
   testinstance:
@@ -94,7 +100,8 @@ Resources:
   testtargetgroup:
     Type: AWS::Inspector::AssessmentTarget
     Properties:
-        AssessmentTargetName : test-targetgroup
+        AssessmentTargetName:
+            Fn::Sub: "test-targetgroup${stackName}"
         ResourceGroupArn :
           Ref: testresourcegroup
 
@@ -103,7 +110,8 @@ Resources:
     Properties:
       AssessmentTargetArn:
         Fn::GetAtt: [ testtargetgroup, Arn ]
-      AssessmentTemplateName: test-template
+      AssessmentTemplateName:
+          Fn::Sub: "test-template${stackName}"
       DurationInSeconds:
           Fn::Sub: "${testTime}"
       RulesPackageArns:
@@ -146,7 +154,8 @@ Resources:
             Action:
               - "sts:AssumeRole"
       Policies:
-          - PolicyName: allow-inspector
+          - PolicyName:
+              Fn::Sub: "allow-inspector${stackName}"
             PolicyDocument:
               Version: "2012-10-17"
               Statement:

--- a/resources/Inspector.yaml
+++ b/resources/Inspector.yaml
@@ -23,7 +23,7 @@ Parameters:
 Conditions:
   OsCheck:
     Fn::Equals:
-      - Fn::Sub: OS
+      - Fn::Sub: ${os}
       - "Windows"
 
 Resources:
@@ -56,6 +56,8 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       InstanceType: t2.micro
+      IamInstanceProfile:
+          Ref: testinstanceprofile
       ImageId:
         Fn::Sub: "${amiId}"
       SubnetId:
@@ -69,8 +71,11 @@ Resources:
           - Fn::Base64:
               Fn::Join:
                 - ''
-                - - "curl -O https://inspector-agent.amazonaws.com/linux/latest/install\n"
-                  - "AWSAgentInstall.exe"
+                - - "<powershell> \n"
+                  - "Start-Transcript -Path \"C:/UserData.log\" -Append \n"
+                  - "Invoke-WebRequest https://inspector-agent.amazonaws.com/windows/installer/latest/AWSAgentInstall.exe -OutFile C:/AWSAgentInstall.exe \n"
+                  - "Start-Process -FilePath C:/AWSAgentInstall.exe -ArgumentList \"/install /quiet /norestart\" -Wait -NoNewWindow -PassThru \n"
+                  - "</powershell>"
           - Fn::Base64:
               Fn::Join:
                 - ''
@@ -153,6 +158,9 @@ Outputs:
       TemplateArn:
             Value:
                    Fn::GetAtt: [ testtemplate, Arn ]
+      TargetsArn:
+            Value:
+                   Fn::GetAtt: [ testtargetgroup, Arn ]
       InstanceId:
             Value:
                   Ref: testinstance

--- a/resources/Inspector.yaml
+++ b/resources/Inspector.yaml
@@ -54,8 +54,7 @@ Resources:
     Properties:
       Roles:
           - Fn::Sub: "testinstancerole${stackName}"
-    DependsOn:
-        Fn::Sub: "testinstancerole${stackName}"
+    DependsOn: testInstanceRole
 
 
   testinstance:

--- a/resources/Inspector.yaml
+++ b/resources/Inspector.yaml
@@ -23,7 +23,7 @@ Parameters:
 Conditions:
   OsCheck:
     Fn::Equals:
-      - Fn::Sub: ${os}
+      - Fn::Sub: OS
       - "Windows"
 
 Resources:
@@ -56,8 +56,6 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       InstanceType: t2.micro
-      IamInstanceProfile:
-          Ref: testinstanceprofile
       ImageId:
         Fn::Sub: "${amiId}"
       SubnetId:
@@ -71,11 +69,8 @@ Resources:
           - Fn::Base64:
               Fn::Join:
                 - ''
-                - - "<powershell> \n"
-                  - "Start-Transcript -Path \"C:/UserData.log\" -Append \n"
-                  - "Invoke-WebRequest https://inspector-agent.amazonaws.com/windows/installer/latest/AWSAgentInstall.exe -OutFile C:/AWSAgentInstall.exe \n"
-                  - "Start-Process -FilePath C:/AWSAgentInstall.exe -ArgumentList \"/install /quiet /norestart\" -Wait -NoNewWindow -PassThru \n"
-                  - "</powershell>"
+                - - "curl -O https://inspector-agent.amazonaws.com/linux/latest/install\n"
+                  - "AWSAgentInstall.exe"
           - Fn::Base64:
               Fn::Join:
                 - ''
@@ -158,9 +153,6 @@ Outputs:
       TemplateArn:
             Value:
                    Fn::GetAtt: [ testtemplate, Arn ]
-      TargetsArn:
-            Value:
-                   Fn::GetAtt: [ testtargetgroup, Arn ]
       InstanceId:
             Value:
                   Ref: testinstance

--- a/vars/runInspector.groovy
+++ b/vars/runInspector.groovy
@@ -22,7 +22,6 @@ import com.amazonaws.services.inspector.model.DescribeAssessmentRunsRequest
 import com.amazonaws.services.ec2.AmazonEC2ClientBuilder
 import com.amazonaws.services.ec2.model.DescribeImagesRequest
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest
-import com.amazonaws.services.ec2.model.DescribeVpcsRequest
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.s3.model.CreateBucketRequest
 import com.base2.ciinabox.aws.Util
@@ -40,7 +39,6 @@ def call(body) {
     } catch(Exception e) {
         println("Error: ${e}")
         println("inspector failed to complete it's run, cleaning up resources before erroring out")
-        cleanUp(stackName, body.region, bucketName, fileName)
         throw e
     }
     // Fail the pipeline if insepctor tests did not pass considering passed in threshold

--- a/vars/runInspector.groovy
+++ b/vars/runInspector.groovy
@@ -22,6 +22,7 @@ import com.amazonaws.services.inspector.model.DescribeAssessmentRunsRequest
 import com.amazonaws.services.ec2.AmazonEC2ClientBuilder
 import com.amazonaws.services.ec2.model.DescribeImagesRequest
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest
+import com.amazonaws.services.ec2.model.DescribeVpcsRequest
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.s3.model.CreateBucketRequest
 import com.base2.ciinabox.aws.Util

--- a/vars/runInspector.groovy
+++ b/vars/runInspector.groovy
@@ -40,6 +40,7 @@ def call(body) {
     } catch(Exception e) {
         println("Error: ${e}")
         println("inspector failed to complete it's run, cleaning up resources before erroring out")
+        cleanUp(stackName, body.region, bucketName, fileName)
         throw e
     }
     // Fail the pipeline if insepctor tests did not pass considering passed in threshold

--- a/vars/runInspector.groovy
+++ b/vars/runInspector.groovy
@@ -68,7 +68,7 @@ def main(body, stackName, bucketName, fileName) {
     println("The AMI is using ${os} based operating system")
 
     // Organise which parameters to send
-    def params = ['amiId': body.amiId, 'os': os]
+    def params = ['amiId': body.amiId, 'os': os, 'stackName': stackName[-6..-1]]
     if (body.subnetId) {
         params['subnetId'] = body.subnetId
     }


### PR DESCRIPTION
Fixed issue where multiple stacks could not co-exist due to static naming. 