### PR TITLE
Changeset - Fix GString encoding issue on stack status

### DIFF
--- a/vars/createChangeSet.groovy
+++ b/vars/createChangeSet.groovy
@@ -74,6 +74,8 @@ def call(body) {
 
   def changeSetName = config.get('changeSetName', "cs-${UUID.randomUUID().toString()}")
   def stackNameUpper = config.stackName.toUpperCase().replaceAll("-", "_")
+  // Converting the stackName to a string prevents passing a Groovy encoded string 
+  // to this script, resulting in null being returned when searching for the stack
   def stackName = config.stackName.toString()
   env["${stackNameUpper}_CHANGESET_NAME"] = changeSetName
   

--- a/vars/createChangeSet.groovy
+++ b/vars/createChangeSet.groovy
@@ -74,6 +74,7 @@ def call(body) {
 
   def changeSetName = config.get('changeSetName', "cs-${UUID.randomUUID().toString()}")
   def stackNameUpper = config.stackName.toUpperCase().replaceAll("-", "_")
+  def stackName = config.stackName.toString()
   env["${stackNameUpper}_CHANGESET_NAME"] = changeSetName
   
   def clientBuilder = new AwsClientBuilder([
@@ -84,7 +85,7 @@ def call(body) {
     env: env])
     
   createChangeSet(clientBuilder, changeSetName, config)
-  def success = wait(clientBuilder, changeSetName, config.stackName, true)
+  def success = wait(clientBuilder, changeSetName, stackName, true)
 
   def failOnEmptyChangeSet = config.get('failOnEmptyChangeSet', false)
   // if there were no changes in our changeset
@@ -93,16 +94,16 @@ def call(body) {
     return null
   }
 
-  def stackChanges = getChangeSetDetails(clientBuilder, config.stackName, changeSetName)
+  def stackChanges = getChangeSetDetails(clientBuilder, stackName, changeSetName)
   def changeMap = [
     changeset: changeSetName,
-    stack: config.stackName,
+    stack: stackName,
     region: config.region,
     changes: []
   ]
 
   if (stackChanges) {
-    changeMap.changes << collectChanges(stackChanges, config.stackName)
+    changeMap.changes << collectChanges(stackChanges, stackName)
     def nestedStacks = collectNestedStacks(stackChanges)
 
     def nestedChanges = null
@@ -121,7 +122,7 @@ def call(body) {
         } 
       }
     }
-    printChanges(changeMap.changes,config.stackName)
+    printChanges(changeMap.changes,stackName)
   }
 
   return changeMap
@@ -130,11 +131,11 @@ def call(body) {
 
 def createChangeSet(clientBuilder,changeSetName,config) {
   def cfclient = clientBuilder.cloudformation()
-  def cfstack = new CloudformationStack(clientBuilder, config.stackName)
+  def cfstack = new CloudformationStack(clientBuilder, stackName)
   def changeSetType = cfstack.getChangeSetType()
 
   def request = new CreateChangeSetRequest()
-    .withStackName(config.stackName)
+    .withStackName(stackName)
     .withChangeSetType(changeSetType)
     .withDescription(config.get('description','ciinabox automated change set'))
     .withChangeSetName(changeSetName)
@@ -174,7 +175,7 @@ def createChangeSet(clientBuilder,changeSetName,config) {
     request.withIncludeNestedStacks(true)
   }
 
-  steps.echo "Creating change set ${changeSetName} for stack ${config.stackName} with operation ${changeSetType}"
+  steps.echo "Creating change set ${changeSetName} for stack ${stackName} with operation ${changeSetType}"
 
   try {
     cfclient.createChangeSet(request)

--- a/vars/createChangeSet.groovy
+++ b/vars/createChangeSet.groovy
@@ -84,7 +84,7 @@ def call(body) {
     maxErrorRetry: config.get('maxErrorRetry', 3),
     env: env])
     
-  createChangeSet(clientBuilder, changeSetName, config)
+  createChangeSet(clientBuilder, changeSetName, stackName, config)
   def success = wait(clientBuilder, changeSetName, stackName, true)
 
   def failOnEmptyChangeSet = config.get('failOnEmptyChangeSet', false)
@@ -129,7 +129,7 @@ def call(body) {
 }
 
 
-def createChangeSet(clientBuilder,changeSetName,config) {
+def createChangeSet(clientBuilder,changeSetName,stackName,config) {
   def cfclient = clientBuilder.cloudformation()
   def cfstack = new CloudformationStack(clientBuilder, stackName)
   def changeSetType = cfstack.getChangeSetType()

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -30,6 +30,7 @@ import java.util.concurrent.Future
 def call(body) {
   def config = body
   def stackNameUpper = config.stackName.toUpperCase().replaceAll("-", "_")
+  def stackName = config.stackName.toString()
 
   if (env["${stackNameUpper}_NO_EXECUTE_CHANGESET"] == 'TRUE') {
     echo("Skipping execution changeset as no changes have been detected ...")
@@ -49,7 +50,7 @@ def apply(config, stackNameUpper) {
     
   def cfclient = clientBuilder.cloudformation()
 
-  def cfstack = new CloudformationStack(clientBuilder, config.stackName)
+  def cfstack = new CloudformationStack(clientBuilder, stackName)
   def changeSetType = cfstack.getChangeSetType()
   cfStack = null
   cfclient = null
@@ -62,16 +63,16 @@ def apply(config, stackNameUpper) {
   }
 
   echo "Executing change set ${changeSetName}"
-  executeChangeSet(clientBuilder, config.stackName, changeSetName)
-  def success = wait(clientBuilder, config.stackName, changeSetType)
+  executeChangeSet(clientBuilder, stackName, changeSetName)
+  def success = wait(clientBuilder, stackName, changeSetType)
 
   if (!success) {
     cfclient = clientBuilder.cloudformation()
-    def events = new CloudformationStackEvents(cfclient, config.region, config.stackName)
+    def events = new CloudformationStackEvents(cfclient, config.region, stackName)
     echo events.getFailedEventsTable()
     events = null
     cfclient = null
-    error "${config.stackName} changeset ${changeSetName} failed to execute."
+    error "${stackName} changeset ${changeSetName} failed to execute."
   }
   
   cfclient = null

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -35,11 +35,11 @@ def call(body) {
   if (env["${stackNameUpper}_NO_EXECUTE_CHANGESET"] == 'TRUE') {
     echo("Skipping execution changeset as no changes have been detected ...")
   } else {
-    apply(config, stackNameUpper)
+    apply(config, stackName, stackNameUpper)
   }
 }
 
-def apply(config, stackNameUpper) {
+def apply(config, stackName, stackNameUpper) {
   
   def clientBuilder = new AwsClientBuilder([
     region: config.region,

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -30,6 +30,8 @@ import java.util.concurrent.Future
 def call(body) {
   def config = body
   def stackNameUpper = config.stackName.toUpperCase().replaceAll("-", "_")
+  // Converting the stackName to a string prevents passing a Groovy encoded string 
+  // to this script, resulting in null being returned when searching for the stack
   def stackName = config.stackName.toString()
 
   if (env["${stackNameUpper}_NO_EXECUTE_CHANGESET"] == 'TRUE') {


### PR DESCRIPTION
When a "Gstring" / Groovy string is passed to the createChangeSet or executeChangeSet as the stack name, it returns null because instead of searching for (for example) stack-${params.envName} (stack-dev) it would  search for "stack-"