### PR TITLE
Filter unique tags

### DIFF
--- a/vars/dockerBuild.groovy
+++ b/vars/dockerBuild.groovy
@@ -25,7 +25,7 @@ def call(body) {
   // evaluate the body block, and collect configuration into the object
   def config = body
 
-  def tags = config.get('tags',['latest'])
+  def tags = config.get('tags',['latest']).unique()
   def dockerRepo = "${config.repo}/${config.image}"
   def buildDir = config.get('dir', '.')
   def dockerfile = config.get('dockerfile', 'Dockerfile')

--- a/vars/dockerBuildx.groovy
+++ b/vars/dockerBuildx.groovy
@@ -30,7 +30,7 @@ def call(body) {
   // evaluate the body block, and collect configuration into the object
   def config = body
 
-  def tags = config.get('tags',['latest'])
+  def tags = config.get('tags',['latest']).unique()
   def dockerRepo = "${config.repo}/${config.image}"
   def buildDir = config.get('dir', '.')
   def dockerfile = config.get('dockerfile', 'Dockerfile')


### PR DESCRIPTION
### Issue
While using dockerBuild or dockerBuildx functions passing duplicated values on tags with cleanup flag enabled, Jenkins tries to delete the same image twice and fails to do so.

```
dockerBuild repo: env.ECR_REPO,
  image: env.PROJECT_NAME,
  tags: ['test',  'test'],
  push: true,
  cleanup: true
```

```
[Pipeline] sh
+ docker rmi ############.dkr.ecr.us-east-1.amazonaws.com/test-docker-tags:test
Untagged: ############.dkr.ecr.us-east-1.amazonaws.com/test-docker-tags:test
Untagged: ############.dkr.ecr.us-east-1.amazonaws.com/test-docker-tags@sha256:206be68211e33e0245ab42ea53e4fe10aa41dcfe6c04b34609b9e6e40bcd050e
Deleted: sha256:1ff884df1be23ca1e5b0b254d19de71fcb97bb512529861ae71977e2984e1168
Deleted: sha256:2cde73e587b61cbfdd136b83928bf8c2c2b49e75e4f482cffa441ae92712437d
[Pipeline] sh
+ docker rmi ############.dkr.ecr.us-east-1.amazonaws.com/test-docker-tags:test
Error: No such image: ############.dkr.ecr.us-east-1.amazonaws.com/test-docker-tags:test
```

### Solution
Filter unique value from tags
`def tags = config.get('tags',['latest']).unique()`

### Test
Result from same Jenkinsfile after applying the changes to the shared pipeline
```
+ docker build -t ############.dkr.ecr.us-east-1.amazonaws.com/test-docker-tags:test -f Dockerfile .
Sending build context to Docker daemon  67.07kB

Step 1/2 : FROM alpine
 ---> c059bfaa849c
Step 2/2 : RUN echo 'hello world!' > /hello_world.txt
 ---> Running in 4c1771927edd
Removing intermediate container 4c1771927edd
 ---> 5a227f190129
Successfully built 5a227f190129
Successfully tagged ############.dkr.ecr.us-east-1.amazonaws.com/test-docker-tags:test
[Pipeline] sh
+ docker push ############.dkr.ecr.us-east-1.amazonaws.com/test-docker-tags:test
The push refers to repository [############.dkr.ecr.us-east-1.amazonaws.com/test-docker-tags]
b89a5d7ffedd: Preparing
8d3ac3489996: Preparing
8d3ac3489996: Layer already exists
b89a5d7ffedd: Pushed
test: digest: sha256:2bc0d0928746afc45ae804db3d607c747b27fae6126441908d05ba5d4e40c3bd size: 735
[Pipeline] sh
+ docker rmi ############.dkr.ecr.us-east-1.amazonaws.com/test-docker-tags:test
Untagged: ############.dkr.ecr.us-east-1.amazonaws.com/test-docker-tags:test
Untagged: ############.dkr.ecr.us-east-1.amazonaws.com/test-docker-tags@sha256:2bc0d0928746afc45ae804db3d607c747b27fae6126441908d05ba5d4e40c3bd
Deleted: sha256:5a227f190129af1c5294c6d8f10a04ce0f0663e0610547f4abe767dbf1fb44b6
Deleted: sha256:269fb8aaf3f208f65822f8d04894dc700160c07c32b980d0ee8349b51864a474
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
[Checks API] No suitable checks publisher found.
Finished: SUCCESS
```
.
.