### PR TITLE
Update 7zip to latest version

### DIFF
--- a/resources/packer/install_7zip.ps1
+++ b/resources/packer/install_7zip.ps1
@@ -9,7 +9,7 @@
 #>
 
 param (
-  [string]$version = "1900"
+  [string]$version = "2107"
 )
 
 $ErrorActionPreference = "Stop"


### PR DESCRIPTION
The current version is not a valid package, thus causing packer to fail.