### PR TITLE
Feature/fix washerysnapshotrestore syntax

### DIFF
--- a/vars/ssmParameter.groovy
+++ b/vars/ssmParameter.groovy
@@ -103,6 +103,7 @@ def assumeRole(awsAccountId, region, roleName) {
 @NonCPS
 def getSSMParams(ssm, path) {
   def ssmParams = []
+  println "Getting ssm params for path: ${path}"
   def result = ssm.getParametersByPath(new GetParametersByPathRequest()
     .withPath(path)
     .withRecursive(false)
@@ -120,5 +121,7 @@ def getSSMParams(ssm, path) {
     )
     ssmParams += result.parameters
   }
+  def len = ssmParams.length()
+  println "param len: ${len}"
   return ssmParams
 }

--- a/vars/ssmParameter.groovy
+++ b/vars/ssmParameter.groovy
@@ -103,7 +103,6 @@ def assumeRole(awsAccountId, region, roleName) {
 @NonCPS
 def getSSMParams(ssm, path) {
   def ssmParams = []
-  println "Getting ssm params for path: ${path}"
   def result = ssm.getParametersByPath(new GetParametersByPathRequest()
     .withPath(path)
     .withRecursive(false)
@@ -121,7 +120,5 @@ def getSSMParams(ssm, path) {
     )
     ssmParams += result.parameters
   }
-  def len = ssmParams.length()
-  println "param len: ${len}"
   return ssmParams
 }

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -83,8 +83,8 @@ def call(body) {
             accountId: config.accountId,
             role: config.role
         )
-
-        def path = config.resetMasterPassword - config.resetMasterPassword.substring(parameter.lastIndexOf("/"))
+            
+        def path = config.resetMasterPassword - config.resetMasterPassword.substring(config.resetMasterPassword.lastIndexOf("/")) 
             password = ssmParameter(
             action: 'get',
             parameter: path,

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -91,6 +91,9 @@ def call(body) {
 
         println "resetting the ${config.type} master password with the value found in parameter ${config.resetMasterPassword}"
 
+        println "client: ${client}"
+        println "resource: ${resourceId}"
+
         "$passwordResetHandler"(client, resourceId, password)
     }
 }

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -83,15 +83,17 @@ def call(body) {
             accountId: config.accountId,
             role: config.role
         )
-            
         def path = config.resetMasterPassword - config.resetMasterPassword.substring(config.resetMasterPassword.lastIndexOf("/")) 
-            password = ssmParameter(
+
+        ssmParams = ssmParameter(
             action: 'get',
             parameter: path,
             region: config.region,
             accountId: config.accountId,
             role: config.role
         )
+
+        password = getSSMParamValue(ssmParams, config.resetMasterPassword)
 
         println "resetting the ${config.type} master password with the value found in parameter ${config.resetMasterPassword}"
 
@@ -101,6 +103,16 @@ def call(body) {
 
         "$passwordResetHandler"(client, resourceId, password)
     }
+}
+
+def getSSMParamValue(ssmParams, name) {
+    def value = null
+    ssmParams.each { p ->
+        if(p.name == name) {
+            value = p.value
+        }
+    }
+    return value
 }
 
 def handleDbClusterPasswordReset(client, clusterId, password) {

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -83,9 +83,11 @@ def call(body) {
             accountId: config.accountId,
             role: config.role
         )
+
+        def path = config.resetMasterPassword - config.resetMasterPassword.substring(parameter.lastIndexOf("/"))
             password = ssmParameter(
             action: 'get',
-            parameter: config.resetMasterPassword,
+            parameter: path,
             region: config.region,
             accountId: config.accountId,
             role: config.role

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -31,6 +31,9 @@ import com.amazonaws.waiters.WaiterParameters
 
 def call(body) {
     def config = body
+    def client = null
+    def snapshotArn = null
+    def passwordResetHandler = null
 
     def clientBuilder = new AwsClientBuilder([
         region: config.region,

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -44,7 +44,7 @@ def call(body) {
     if (config.type.toLowerCase() == 'rds') {
         client = clientBuilder.rds()
         snapshotArn = "arn:aws:rds:${config.region}:${config.accountId}:snapshot:${config.snapshot}"
-        passwordResetHandler = "handleDbInstancePasswordReset"`
+        passwordResetHandler = "handleDbInstancePasswordReset"
     } else if (config.type.toLowerCase() == 'dbcluster') {
         client = clientBuilder.rds()
         snapshotArn = "arn:aws:rds:${config.region}:${config.accountId}:cluster-snapshot:${config.snapshot}"

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -123,7 +123,7 @@ def handleDbClusterPasswordReset(client, clusterId, password) {
     client.modifyDBCluster(modifyDBClusterRequest)
 
     println "password has been reset, waiting for the change to be applied to the rds cluster"
-    waitTillDbClusterAvailable(client, clusterId)
+    //waitTillDbClusterAvailable(client, clusterId)
 }
 
 def waitTillDbClusterAvailable(client, clusterId) {
@@ -155,7 +155,7 @@ def handleDbInstancePasswordReset(client, instanceId, password) {
     client.modifyDBInstance(modifyDBInstanceRequest)
 
     println "password has been reset, waiting for the change to be applied to the rds instance"
-    waitTillDbInstanceAvailable(client, instanceId)
+    //waitTillDbInstanceAvailable(client, instanceId)
 }
 
 def waitTillDbInstanceAvailable(client, instanceId) {

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -52,6 +52,9 @@ def call(body) {
     } else {
         throw new GroovyRuntimeException("washerySnapshotRestore() doesn't support type ${config.type}")
     }
+    
+    println "Parameter name:" "${config.snapshotParameterName}"
+    println "snapshot ARN: ${snapshotArn}"
 
     autoApproveChangeSet = config.get('autoApproveChangeSet', false)
 

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -93,9 +93,7 @@ def call(body) {
 
         println "resetting the ${config.type} master password with the value found in parameter ${config.resetMasterPassword}"
 
-        if (password){
-            print("password exists")
-        }
+        print("${password}")
         println "client: ${client}"
         println "resource: ${resourceId}"
 

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -10,6 +10,7 @@ example usage
     role: env.ROLE,
     type: 'rds|dbcluster',
     snapshot: env.WASHERY_FINAL_SNAPSHOT, // the snapshot id of the snapshot created by washery
+    snapshotAccountId: env.DEV_ACCOUNT, // account where the snapshot exists in
     resetMasterPassword: '/db/password', // rest the master password to the value in this ssm parameter
     stackName: 'dev', // name of the cloudformation stack with the RDS you are restoring
     snapshotParameterName: 'SnapshotID', // name of the RDS snapshot cloudformation parameter

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -76,14 +76,14 @@ def call(body) {
     )
 
     if (config.resetMasterPassword && config.resourceIdExportName) {
-        def resourceId = cloudformation(
+            resourceId = cloudformation(
             queryType: 'export',
             query: config.resourceIdExportName,
             region: config.region,
             accountId: config.accountId,
             role: config.role
         )
-        def password = ssmParameter(
+            password = ssmParameter(
             action: 'get',
             parameter: config.resetMasterPassword,
             region: config.region,
@@ -93,7 +93,9 @@ def call(body) {
 
         println "resetting the ${config.type} master password with the value found in parameter ${config.resetMasterPassword}"
 
-        println "${password}"
+        if (password){
+            print("password exists")
+        }
         println "client: ${client}"
         println "resource: ${resourceId}"
 

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -71,7 +71,7 @@ def call(body) {
             role: config.role
         )
         def password = ssmParameter(
-            action: 'get'
+            action: 'get',
             parameter: config.snapshotParameterName,
             region: config.region,
             accountId: config.accountId,

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -73,7 +73,7 @@ def call(body) {
         nestedStacks: true
     )
 
-    if (config.resetMasterPassword && config.resourceIdExportName && config.snapshotParameterName) {
+    if (config.resetMasterPassword && config.resourceIdExportName) {
         def resourceId = cloudformation(
             queryType: 'export',
             query: config.resourceIdExportName,
@@ -83,13 +83,13 @@ def call(body) {
         )
         def password = ssmParameter(
             action: 'get',
-            parameter: config.snapshotParameterName,
+            parameter: config.resetMasterPassword,
             region: config.region,
             accountId: config.accountId,
             role: config.role
         )
 
-        println "resetting the ${config.type} master password with the value found in parameter ${config.snapshotParameterName}"
+        println "resetting the ${config.type} master password with the value found in parameter ${config.resetMasterPassword}"
 
         "$passwordResetHandler"(client, resourceId, password)
     }

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -42,13 +42,13 @@ def call(body) {
     ])
 
     if (config.type.toLowerCase() == 'rds') {
-        def client = clientBuilder.rds()
-        def snapshotArn = "arn:aws:rds:${config.region}:${config.accountId}:snapshot:${config.snapshot}"
-        def passwordResetHandler = "handleDbClusterPasswordReset"
+        client = clientBuilder.rds()
+        snapshotArn = "arn:aws:rds:${config.region}:${config.accountId}:snapshot:${config.snapshot}"
+        passwordResetHandler = "handleDbClusterPasswordReset"
     } else if (config.type.toLowerCase() == 'dbcluster') {
-        def client = clientBuilder.rds()
-        def snapshotArn = "arn:aws:rds:${config.region}:${config.accountId}:cluster-snapshot:${config.snapshot}"
-        def passwordResetHandler = "handleDbInstancePasswordReset"
+        client = clientBuilder.rds()
+        snapshotArn = "arn:aws:rds:${config.region}:${config.accountId}:cluster-snapshot:${config.snapshot}"
+        passwordResetHandler = "handleDbInstancePasswordReset"
     } else {
         throw new GroovyRuntimeException("washerySnapshotRestore() doesn't support type ${config.type}")
     }

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -35,6 +35,8 @@ def call(body) {
     def client = null
     def snapshotArn = null
     def passwordResetHandler = null
+    def resourceId = null
+    def password = null
     def snapshotAccountId = config.get('snapshotAccountId', config.accountId)
 
     def clientBuilder = new AwsClientBuilder([
@@ -91,6 +93,7 @@ def call(body) {
 
         println "resetting the ${config.type} master password with the value found in parameter ${config.resetMasterPassword}"
 
+        println "${password}"
         println "client: ${client}"
         println "resource: ${resourceId}"
 

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -37,11 +37,11 @@ def call(body) {
 
     if (config.type.toLowerCase() == 'rds') {
         def client = clientBuilder.rds()
-        def shapshotArn = "arn:aws:rds:${config.region}:${config.accountId}:snapshot:${config.snapshot}"
+        def snapshotArn = "arn:aws:rds:${config.region}:${config.accountId}:snapshot:${config.snapshot}"
         def passwordResetHandler = "handleDbClusterPasswordReset"
     } else if (config.type.toLowerCase() == 'dbcluster') {
         def client = clientBuilder.rds()
-        def shapshotArn = "arn:aws:rds:${config.region}:${config.accountId}:cluster-snapshot:${config.snapshot}"
+        def snapshotArn = "arn:aws:rds:${config.region}:${config.accountId}:cluster-snapshot:${config.snapshot}"
         def passwordResetHandler = "handleDbInstancePasswordReset"
     } else {
         throw new GroovyRuntimeException("washerySnapshotRestore() doesn't support type ${config.type}")
@@ -56,7 +56,7 @@ def call(body) {
         awsAccountId: config.accountId,
         role: config.role,
         parameters: [ 
-            config.snapshotParameterName : shapshotArn
+            "${config.snapshotParameterName}" : shapshotArn
         ],
         approveChanges: autoApproveChangeSet,
         nestedStacks: true

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -25,6 +25,9 @@ import com.amazonaws.services.rds.model.DescribeDBClustersRequest
 import com.amazonaws.services.rds.model.ModifyDBInstanceRequest
 import com.amazonaws.services.rds.model.DescribeDBInstancesRequest
 import com.base2.ciinabox.aws.AwsClientBuilder
+import java.util.concurrent.Future
+import com.amazonaws.waiters.NoOpWaiterHandler
+import com.amazonaws.waiters.WaiterParameters
 
 def call(body) {
     def config = body

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -59,7 +59,7 @@ def call(body) {
         awsAccountId: config.accountId,
         role: config.role,
         parameters: [ 
-            "${config.snapshotParameterName}" : shapshotArn
+            "${config.snapshotParameterName}" : snapshotArn
         ],
         approveChanges: autoApproveChangeSet,
         nestedStacks: true

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -97,7 +97,7 @@ def call(body) {
 
         println "resetting the ${config.type} master password with the value found in parameter ${config.resetMasterPassword}"
 
-        print("${password}")
+
         println "client: ${client}"
         println "resource: ${resourceId}"
 

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -34,6 +34,7 @@ def call(body) {
     def client = null
     def snapshotArn = null
     def passwordResetHandler = null
+    def snapshotAccountId = config.get('snapshotAccountId', config.accountId)
 
     def clientBuilder = new AwsClientBuilder([
         region: config.region,
@@ -43,11 +44,11 @@ def call(body) {
 
     if (config.type.toLowerCase() == 'rds') {
         client = clientBuilder.rds()
-        snapshotArn = "arn:aws:rds:${config.region}:${config.accountId}:snapshot:${config.snapshot}"
+        snapshotArn = "arn:aws:rds:${config.region}:${snapshotAccountId}:snapshot:${config.snapshot}"
         passwordResetHandler = "handleDbInstancePasswordReset"
     } else if (config.type.toLowerCase() == 'dbcluster') {
         client = clientBuilder.rds()
-        snapshotArn = "arn:aws:rds:${config.region}:${config.accountId}:cluster-snapshot:${config.snapshot}"
+        snapshotArn = "arn:aws:rds:${config.region}:${snapshotAccountId}:cluster-snapshot:${config.snapshot}"
         passwordResetHandler = "handleDbClusterPasswordReset"
     } else {
         throw new GroovyRuntimeException("washerySnapshotRestore() doesn't support type ${config.type}")

--- a/vars/washerySnapshotRestore.groovy
+++ b/vars/washerySnapshotRestore.groovy
@@ -44,16 +44,16 @@ def call(body) {
     if (config.type.toLowerCase() == 'rds') {
         client = clientBuilder.rds()
         snapshotArn = "arn:aws:rds:${config.region}:${config.accountId}:snapshot:${config.snapshot}"
-        passwordResetHandler = "handleDbClusterPasswordReset"
+        passwordResetHandler = "handleDbInstancePasswordReset"`
     } else if (config.type.toLowerCase() == 'dbcluster') {
         client = clientBuilder.rds()
         snapshotArn = "arn:aws:rds:${config.region}:${config.accountId}:cluster-snapshot:${config.snapshot}"
-        passwordResetHandler = "handleDbInstancePasswordReset"
+        passwordResetHandler = "handleDbClusterPasswordReset"
     } else {
         throw new GroovyRuntimeException("washerySnapshotRestore() doesn't support type ${config.type}")
     }
     
-    println "Parameter name:" "${config.snapshotParameterName}"
+    println "Parameter name: ${config.snapshotParameterName}"
     println "snapshot ARN: ${snapshotArn}"
 
     autoApproveChangeSet = config.get('autoApproveChangeSet', false)


### PR DESCRIPTION
 ### Fixed washery snapshot restore syntax issues
- Added `snapshotAccountId` parameter which identifies account id of snapshot 
- Added missing imports
- Removed waiters (for now)
- Fixed various syntax issues
- Changed retrieval of SSM parameter
