### PR TITLE
Feature/execute changeset credentials refresh

### DIFF
--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -93,8 +93,8 @@ def executeChangeSet(clientBuilder, stackName, changeSetName) {
 
 def wait(clientBuilder, stackName, changeSetType) {
   def cfclient = clientBuilder.cloudformation()
-  def creds = cfclient.getCredentials()
   def waiter = null
+  def count = 0
   switch(changeSetType) {
     case 'CREATE':
       waiter = cfclient.waiters().stackCreateComplete()
@@ -113,10 +113,20 @@ def wait(clientBuilder, stackName, changeSetType) {
       try {
         echo "waiting for execute changeset to ${changeSetType.toLowerCase()} ..."
         Thread.sleep(10000)
-        echo "${creds}"
-        echo "about to refresh creds"
-        creds.refresh()
-        echo "${creds}"
+        count++
+        if count > 1 {
+          def cfclient = clientBuilder.cloudformation()
+          def waiter = null
+          switch(changeSetType) {
+            case 'CREATE':
+              waiter = cfclient.waiters().stackCreateComplete()
+              break
+            default:
+              waiter = cfclient.waiters().stackUpdateComplete()
+              break
+          }
+        }
+
       } catch(InterruptedException ex) {
           // suppress and continue
       }

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -18,7 +18,6 @@ executeChangeSet(
 import com.base2.ciinabox.aws.AwsClientBuilder
 import com.base2.ciinabox.aws.CloudformationStack
 import com.base2.ciinabox.aws.CloudformationStackEvents
-import com.amazonaws.auth.AWSStaticCredentialsProvider
 
 import com.amazonaws.services.cloudformation.model.ExecuteChangeSetRequest
 import com.amazonaws.services.cloudformation.model.DescribeStacksRequest
@@ -114,19 +113,11 @@ def wait(clientBuilder, stackName, changeSetType) {
         echo "waiting for execute changeset to ${changeSetType.toLowerCase()} ..."
         Thread.sleep(10000)
         count++
+        // Initialise new client and waiter if count exceeds set timeout value
         if (count > 1) {
-          echo "initialising new client and waiter"
-          cfclient = clientBuilder.cloudformation()
-          echo "created client"
-          switch(changeSetType) {
-            case 'CREATE':
-              waiter = cfclient.waiters().stackCreateComplete()
-              break
-            default:
-              waiter = cfclient.waiters().stackUpdateComplete()
-              break
-          }
-          echo "created waiter"
+          cfclient = updateClient(clientBuilder) //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
+          waiter = updateWaiter(cfclient,changeSetType)
+          count = 0
         }
 
       } catch(InterruptedException ex) {
@@ -150,4 +141,23 @@ def wait(clientBuilder, stackName, changeSetType) {
   }
   
   return true
+}
+
+def updateClient(clientBuilder){
+  cfclient = clientBuilder.cloudformation()
+  echo "Created waiter ${cfclient}"
+  return cfclient
+}
+
+def updateWaiter(cfclient, changeSetType){
+  switch(changeSetType) {
+    case 'CREATE':
+      waiter = cfclient.waiters().stackCreateComplete()
+      break
+    default:
+      waiter = cfclient.waiters().stackUpdateComplete()
+      break
+  }
+  echo "Created waiter ${waiter}"
+  return waiter
 }

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -18,6 +18,7 @@ executeChangeSet(
 import com.base2.ciinabox.aws.AwsClientBuilder
 import com.base2.ciinabox.aws.CloudformationStack
 import com.base2.ciinabox.aws.CloudformationStackEvents
+import com.amazonaws.auth.AWSStaticCredentialsProvider
 
 import com.amazonaws.services.cloudformation.model.ExecuteChangeSetRequest
 import com.amazonaws.services.cloudformation.model.DescribeStacksRequest
@@ -92,7 +93,7 @@ def executeChangeSet(clientBuilder, stackName, changeSetName) {
 
 def wait(clientBuilder, stackName, changeSetType) {
   def cfclient = clientBuilder.cloudformation()
-  def creds = getCredentials()
+  def creds = cfclient.getCredentials()
   def waiter = null
   switch(changeSetType) {
     case 'CREATE':

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -113,9 +113,14 @@ def wait(clientBuilder, stackName, changeSetType) {
         echo "waiting for execute changeset to ${changeSetType.toLowerCase()} ..."
         Thread.sleep(10000)
         count++
-        echo "Wait - ${cfclient}"
-        checkClientTimeout(count,1, clientBuilder, changeSetType) //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
-        echo "Wait - ${cfclient}"
+        echo "${cfclient}"
+        echo "${waiter}"
+        if (count > 1) {
+          cfclient = updateClient(clientBuilder) //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
+          waiter = updateWaiter(cfclient,changeSetType)
+          echo "New Client ${cfclient}"
+          echo "New Waiter ${waiter}"
+        }
 
       } catch(InterruptedException ex) {
           // suppress and continue
@@ -140,24 +145,20 @@ def wait(clientBuilder, stackName, changeSetType) {
   return true
 }
 
-def checkClientTimeout(count, limit, clientBuilder, changeSetType){
-  //Limit = Iterations in 10's of seconds eg : 300 = 3000 seconds / 50 mins
-  if (count > limit) {
-    echo "initialising new client and waiter"
-    cfclient = clientBuilder.cloudformation()
-    echo "created client"
-    switch(changeSetType) {
-      case 'CREATE':
-        waiter = cfclient.waiters().stackCreateComplete()
-        break
-      default:
-        waiter = cfclient.waiters().stackUpdateComplete()
-        break
-    }
-    echo "created waiter"
-    echo "Check - ${cfclient}"
+def updateClient(clientBuilder){
+  echo "Initialising new client"
+  return clientBuilder.cloudformation()
+}
+
+def updateWaiter(cfclient, changesetType){
+  switch(changeSetType) {
+    case 'CREATE':
+      waiter = cfclient.waiters().stackCreateComplete()
+      break
+    default:
+      waiter = cfclient.waiters().stackUpdateComplete()
+      break
   }
-  else {
-    echo "client still valid"
-  }
+  echo "Created waiter"
+  return waiter
 }

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -114,20 +114,7 @@ def wait(clientBuilder, stackName, changeSetType) {
         echo "waiting for execute changeset to ${changeSetType.toLowerCase()} ..."
         Thread.sleep(10000)
         count++
-        if (count > 1) {
-          echo "initialising new client and waiter"
-          cfclient = clientBuilder.cloudformation()
-          echo "created client"
-          switch(changeSetType) {
-            case 'CREATE':
-              waiter = cfclient.waiters().stackCreateComplete()
-              break
-            default:
-              waiter = cfclient.waiters().stackUpdateComplete()
-              break
-          }
-          echo "created waiter"
-        }
+        checkClientTimeout(count,1) //2700 seconds = 45 minutes, thread sleep is 10 secs so 270 iterations
 
       } catch(InterruptedException ex) {
           // suppress and continue
@@ -150,4 +137,24 @@ def wait(clientBuilder, stackName, changeSetType) {
   }
   
   return true
+}
+
+def checkClientTimeout(count, limit){
+  if (count > limit) {
+    echo "initialising new client and waiter"
+    cfclient = clientBuilder.cloudformation()
+    echo "created client"
+    switch(changeSetType) {
+      case 'CREATE':
+        waiter = cfclient.waiters().stackCreateComplete()
+        break
+      default:
+        waiter = cfclient.waiters().stackUpdateComplete()
+        break
+    }
+    echo "created waiter"
+  }
+  else {
+    echo "client still valid"
+  }
 }

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -144,20 +144,16 @@ def wait(clientBuilder, stackName, changeSetType) {
 }
 
 def updateClient(clientBuilder){
-  cfclient = clientBuilder.cloudformation()
-  echo "Created waiter ${cfclient}"
-  return cfclient
+  return clientBuilder.cloudformation()
 }
 
 def updateWaiter(cfclient, changeSetType){
   switch(changeSetType) {
     case 'CREATE':
-      waiter = cfclient.waiters().stackCreateComplete()
+      return cfclient.waiters().stackCreateComplete()
       break
     default:
-      waiter = cfclient.waiters().stackUpdateComplete()
+      return cfclient.waiters().stackUpdateComplete()
       break
   }
-  echo "Created waiter ${waiter}"
-  return waiter
 }

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -115,8 +115,8 @@ def wait(clientBuilder, stackName, changeSetType) {
         count++
         echo "Current Client - ${cfclient} & Current Waiter - ${waiter}"
         // Initialise new client and waiter if count exceeds set timeout value
-        if (count > 1) {
-          cfclient = updateClient(clientBuilder) //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
+        if (count > 300) { //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
+          cfclient = updateClient(clientBuilder) 
           waiter = updateWaiter(cfclient,changeSetType)
           count = 0
         }

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -150,7 +150,7 @@ def updateClient(clientBuilder){
   return clientBuilder.cloudformation()
 }
 
-def updateWaiter(cfclient, changesetType){
+def updateWaiter(cfclient, changeSetType){
   switch(changeSetType) {
     case 'CREATE':
       waiter = cfclient.waiters().stackCreateComplete()

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -114,7 +114,7 @@ def wait(clientBuilder, stackName, changeSetType) {
         echo "waiting for execute changeset to ${changeSetType.toLowerCase()} ..."
         Thread.sleep(10000)
         count++
-        if count > 1 {
+        if (count > 1) {
           def cfclient = clientBuilder.cloudformation()
           def waiter = null
           switch(changeSetType) {

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -114,7 +114,7 @@ def wait(clientBuilder, stackName, changeSetType) {
         echo "waiting for execute changeset to ${changeSetType.toLowerCase()} ..."
         Thread.sleep(10000)
         count++
-        checkClientTimeout(count,1) //2700 seconds = 45 minutes, thread sleep is 10 secs so 270 iterations
+        checkClientTimeout(count,1, clientBuilder) //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
 
       } catch(InterruptedException ex) {
           // suppress and continue
@@ -139,7 +139,7 @@ def wait(clientBuilder, stackName, changeSetType) {
   return true
 }
 
-def checkClientTimeout(count, limit){
+def checkClientTimeout(count, limit, clientBuilder){
   if (count > limit) {
     echo "initialising new client and waiter"
     cfclient = clientBuilder.cloudformation()

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -113,7 +113,9 @@ def wait(clientBuilder, stackName, changeSetType) {
         echo "waiting for execute changeset to ${changeSetType.toLowerCase()} ..."
         Thread.sleep(10000)
         count++
+        echo "Wait - ${cfclient}"
         checkClientTimeout(count,1, clientBuilder, changeSetType) //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
+        echo "Wait - ${cfclient}"
 
       } catch(InterruptedException ex) {
           // suppress and continue
@@ -139,6 +141,7 @@ def wait(clientBuilder, stackName, changeSetType) {
 }
 
 def checkClientTimeout(count, limit, clientBuilder, changeSetType){
+  //Limit = Iterations in 10's of seconds eg : 300 = 3000 seconds / 50 mins
   if (count > limit) {
     echo "initialising new client and waiter"
     cfclient = clientBuilder.cloudformation()
@@ -152,6 +155,7 @@ def checkClientTimeout(count, limit, clientBuilder, changeSetType){
         break
     }
     echo "created waiter"
+    echo "Check - ${cfclient}"
   }
   else {
     echo "client still valid"

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -113,6 +113,7 @@ def wait(clientBuilder, stackName, changeSetType) {
         echo "waiting for execute changeset to ${changeSetType.toLowerCase()} ..."
         Thread.sleep(10000)
         count++
+        echo "Current Client - ${cfclient} & Current Waiter - ${waiter}"
         // Initialise new client and waiter if count exceeds set timeout value
         if (count > 1) {
           cfclient = updateClient(clientBuilder) //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
@@ -144,16 +145,22 @@ def wait(clientBuilder, stackName, changeSetType) {
 }
 
 def updateClient(clientBuilder){
-  return clientBuilder.cloudformation()
+  echo "Updating Client"
+  def cfclient = clientBuilder.cloudformation()
+  echo "Created new client - ${cfclient}"
+  return cfclient
 }
 
 def updateWaiter(cfclient, changeSetType){
+  echo "Updating Waiter"
   switch(changeSetType) {
     case 'CREATE':
-      return cfclient.waiters().stackCreateComplete()
-      break
+      def waiter = cfclient.waiters().stackCreateComplete()
+      echo "Created new waiter - ${waiter}"
+      return waiter
     default:
-      return cfclient.waiters().stackUpdateComplete()
-      break
+      def waiter = cfclient.waiters().stackUpdateComplete()
+      echo "Created new waiter - ${waiter}"
+      return waiter
   }
 }

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -92,6 +92,7 @@ def executeChangeSet(clientBuilder, stackName, changeSetName) {
 
 def wait(clientBuilder, stackName, changeSetType) {
   def cfclient = clientBuilder.cloudformation()
+  def creds = getCredentials()
   def waiter = null
   switch(changeSetType) {
     case 'CREATE':
@@ -111,6 +112,10 @@ def wait(clientBuilder, stackName, changeSetType) {
       try {
         echo "waiting for execute changeset to ${changeSetType.toLowerCase()} ..."
         Thread.sleep(10000)
+        echo "${creds}"
+        echo "about to refresh creds"
+        creds.refresh()
+        echo "${creds}"
       } catch(InterruptedException ex) {
           // suppress and continue
       }

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -116,8 +116,7 @@ def wait(clientBuilder, stackName, changeSetType) {
         count++
         if (count > 1) {
           echo "initialising new client and waiter"
-          def cfclient = clientBuilder.cloudformation()
-          def waiter = null
+          cfclient = clientBuilder.cloudformation()
           echo "created client"
           switch(changeSetType) {
             case 'CREATE':

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -115,11 +115,13 @@ def wait(clientBuilder, stackName, changeSetType) {
         count++
         echo "${cfclient}"
         echo "${waiter}"
+        // Initialise new client and waiter if count exceeds set timeout value
         if (count > 1) {
           cfclient = updateClient(clientBuilder) //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
           waiter = updateWaiter(cfclient,changeSetType)
           echo "New Client ${cfclient}"
           echo "New Waiter ${waiter}"
+          count = 0
         }
 
       } catch(InterruptedException ex) {

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -115,8 +115,10 @@ def wait(clientBuilder, stackName, changeSetType) {
         Thread.sleep(10000)
         count++
         if (count > 1) {
+          echo "initialising new client and waiter"
           def cfclient = clientBuilder.cloudformation()
           def waiter = null
+          echo "created client"
           switch(changeSetType) {
             case 'CREATE':
               waiter = cfclient.waiters().stackCreateComplete()
@@ -125,6 +127,7 @@ def wait(clientBuilder, stackName, changeSetType) {
               waiter = cfclient.waiters().stackUpdateComplete()
               break
           }
+          echo "created waiter"
         }
 
       } catch(InterruptedException ex) {

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -18,7 +18,6 @@ executeChangeSet(
 import com.base2.ciinabox.aws.AwsClientBuilder
 import com.base2.ciinabox.aws.CloudformationStack
 import com.base2.ciinabox.aws.CloudformationStackEvents
-import com.amazonaws.auth.AWSStaticCredentialsProvider
 
 import com.amazonaws.services.cloudformation.model.ExecuteChangeSetRequest
 import com.amazonaws.services.cloudformation.model.DescribeStacksRequest
@@ -114,7 +113,7 @@ def wait(clientBuilder, stackName, changeSetType) {
         echo "waiting for execute changeset to ${changeSetType.toLowerCase()} ..."
         Thread.sleep(10000)
         count++
-        checkClientTimeout(count,1, clientBuilder) //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
+        checkClientTimeout(count,1, clientBuilder, changeSetType) //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
 
       } catch(InterruptedException ex) {
           // suppress and continue
@@ -139,7 +138,7 @@ def wait(clientBuilder, stackName, changeSetType) {
   return true
 }
 
-def checkClientTimeout(count, limit, clientBuilder){
+def checkClientTimeout(count, limit, clientBuilder, changeSetType){
   if (count > limit) {
     echo "initialising new client and waiter"
     cfclient = clientBuilder.cloudformation()


### PR DESCRIPTION
- executeChangeset step now re-initializes a new cfclient and waiter when the changeset duration exceeds 50 minutes. This should fix the issue with the security token expiring when the changeset takes longer than an hour to execute.

**Jenkins Example:**
```
Executing change set cs-c1388f8e-ad75-4eda-9b06-935ed8125dd3
[Pipeline] echo
waiting for execute changeset to create ...
[Pipeline] echo
Current Client - com.amazonaws.services.cloudformation.AmazonCloudFormationClient@7a1fe11f & Current Waiter - com.amazonaws.waiters.WaiterImpl@69ca1748
[Pipeline] echo
waiting for execute changeset to create ...
[Pipeline] echo
Current Client - com.amazonaws.services.cloudformation.AmazonCloudFormationClient@7a1fe11f & Current Waiter - com.amazonaws.waiters.WaiterImpl@69ca1748
[Pipeline] echo
Updating Client
[Pipeline] echo
Created new client - com.amazonaws.services.cloudformation.AmazonCloudFormationClient@780b0302
[Pipeline] echo
Updating Waiter
[Pipeline] echo
Created new waiter - com.amazonaws.waiters.WaiterImpl@6ce0438
[Pipeline] echo
waiting for execute changeset to create ...
[Pipeline] echo
Current Client - com.amazonaws.services.cloudformation.AmazonCloudFormationClient@780b0302 & Current Waiter - com.amazonaws.waiters.WaiterImpl@6ce0438
[Pipeline] echo
Change set cs-c1388f8e-ad75-4eda-9b06-935ed8125dd3 CREATED
```
 1) In the above example we observe that the changeset executes with cfclient `AmazonCloudFormationClient@7a1fe11f` and waiter `WaiterImpl@69ca1748`
 2) We then observe that after the internal counter surpasses the defined limit (in this case 1 for testing but 300 in reality), that the Client and Waiter are updated.
3) A new client and waiter are created at `AmazonCloudFormationClient@780b0302` and `WaiterImpl@6ce0438` and assigned as the "Current Client and Waiter" now display the newly created client/waiter references.