### PR TITLE
Feature/washery clean old snapshots

### DIFF
--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -53,7 +53,8 @@ def listClusterWasherySnapshots(client){
     def snapshotsResult = client.describeDBClusterSnapshots(request)
     def snapshots = snapshotsResult.getDBClusterSnapshots()
     def sortedWasherySnapshots = []
-
+    
+    //Retrieve snapshots prefixed with `washery-scrubbed` and sort them into a new list
     if(snapshots.size() > 0) {
        snapshots.sort {a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
        for (int i = 0; i < snapshots.size(); i++) {
@@ -67,7 +68,8 @@ def listClusterWasherySnapshots(client){
     while (sortedWasherySnapshots.size() > 3){
         current_snapshot = sortedWasherySnapshots.shift()
         snapshot_identifier = current_snapshot.getDBClusterSnapshotIdentifier()
-        DeleteDBSnapshotRequest request = new DeleteDBSnapshotRequest().withDBSnapshotIdentifier(snapshot_identifier);
-        DBSnapshot response = client.deleteDBSnapshot(request);
+        def DeleteDBClusterSnapshotRequest delete_request = new DeleteDBClusterSnapshotRequest().withDBClusterSnapshotIdentifier(snapshot_identifier)
+        def DBClusterSnapshot response = client.deleteDBClusterSnapshot(delete_request)
+        echo response
     }
 }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -87,9 +87,10 @@ def cleanClusterWasherySnapshots(client, snapshotRetainCount){
        }
 
         //Sort washery snapshots based on snapshot create time
-        washerySnapshots.sort{a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
+        washerySnapshots.sort{a,b-> b.getSnapshotCreateTime().format('d/M/yyyy HH:mm:ss')<=>a.getSnapshotCreateTime().format('d/M/yyyy HH:mm:ss')}
         for (int i = 0; i < washerySnapshots.size(); i++) {
-            echo "${washerySnapshots[i]}"
+            echo "${washerySnapshots[i].getDBClusterSnapshotIdentifier()}"
+            echo "${washerySnapshots[i].getSnapshotCreateTime().format('d/M/yyyy HH:mm:ss')}"
         }
     }
 

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -30,7 +30,7 @@ def listInstanceWasherySnapshots(client){
     def snapshots = snapshotsResult.getDBSnapshots()
 
     if(snapshots.size() > 0) {
-        def sorted_snaps = snapshots.sort {a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
+        sorted_snaps = snapshots.sort{a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
         echo "${sorted_snaps}"
         echo sorted_snaps
         for (int i = 0; i < sorted_snaps.size(); i++) {

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -53,18 +53,23 @@ def cleanInstanceWasherySnapshots(client, snapshotRetainCount){
             washerySnapshots.add(snapshot)
         }
     }
+
     //Sort washery snapshots based on snapshot create time
     washerySnapshots.sort{a,b-> b.getSnapshotCreateTime().compareTo(a.getSnapshotCreateTime())}
-    def delete = washerySnapshots[snapshotRetainCount..-1]
-    println delete
+    
+    //If retain count is less than the size of the total washery snapshots
+    if (snapshotRetainCount < washerySnapshots.size()){
+        def delete = washerySnapshots[snapshotRetainCount..-1]
+        println delete
 
-    //Delete snapshot's until only the snapshotRetainCount amount remains
-    // for (snapshot in delete) {
-    //     snapshot_identifier = snapshot.getDBSnapshotIdentifier()
-    //     def delete_request = new DeleteDBSnapshotRequest().withDBSnapshotIdentifier(snapshot_identifier)
-    //     def response = client.deleteDBSnapshot(delete_request)
-    //     echo "Deleted Snapshot - ${snapshot_identifier} created on ${current_snapshot.getSnapshotCreateTime()}"
-    // }
+        //Delete snapshot's until only the snapshotRetainCount amount remains
+        // for (snapshot in delete) {
+        //     snapshot_identifier = snapshot.getDBSnapshotIdentifier()
+        //     def delete_request = new DeleteDBSnapshotRequest().withDBSnapshotIdentifier(snapshot_identifier)
+        //     def response = client.deleteDBSnapshot(delete_request)
+        //     echo "Deleted Snapshot - ${snapshot_identifier} created on ${current_snapshot.getSnapshotCreateTime()}"
+        // }
+    }
 }
 
 @NonCPS
@@ -85,14 +90,18 @@ def cleanClusterWasherySnapshots(client, snapshotRetainCount){
 
     //Sort washery snapshots based on snapshot create time
     washerySnapshots.sort{a,b-> b.getSnapshotCreateTime().compareTo(a.getSnapshotCreateTime())}
-    def delete = washerySnapshots[snapshotRetainCount..-1]
-    println delete
 
-    //Delete snapshot's until only the snapshotRetainCount amount remains
-    // for (snapshot in delete) {
-    //     snapshot_identifier = snapshot.getDBClusterSnapshotIdentifier()
-    //     def delete_request = new DeleteDBSnapshotRequest().withDBClusterSnapshotIdentifier(snapshot_identifier)
-    //     def response = client.deleteDBClusterSnapshot(delete_request)
-    //     echo "Deleted Snapshot - ${snapshot_identifier} created on ${current_snapshot.getSnapshotCreateTime()}"
-    // }
+    //If retain count is less than the size of the total washery snapshots
+    if (snapshotRetainCount < washerySnapshots.size()){
+        def delete = washerySnapshots[snapshotRetainCount..-1]
+        println delete
+
+        //Delete snapshot's until only the snapshotRetainCount amount remains
+        // for (snapshot in delete) {
+        //     snapshot_identifier = snapshot.getDBClusterSnapshotIdentifier()
+        //     def delete_request = new DeleteDBSnapshotRequest().withDBClusterSnapshotIdentifier(snapshot_identifier)
+        //     def response = client.deleteDBClusterSnapshot(delete_request)
+        //     echo "Deleted Snapshot - ${snapshot_identifier} created on ${current_snapshot.getSnapshotCreateTime()}"
+        // }
+    }
 }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -30,7 +30,9 @@ def listInstanceWasherySnapshots(client){
     def snapshots = snapshotsResult.getDBSnapshots()
 
     for (int i = 0; i < snapshots.size(); i++) {
-        echo snapshots[i].getDBSnapshotIdentifier()
+        if (snapshots[i].getDBSnapshotIdentifier().startsWith("washery-scrubbed-")){
+            echo snapshots[i].getDBSnapshotIdentifier()
+        }
     }
 
 }
@@ -44,7 +46,9 @@ def listClusterWasherySnapshots(client){
     def snapshots = snapshotsResult.getDBClusterSnapshots()
 
     for (int i = 0; i < snapshots.size(); i++) {
-        echo snapshots[i].getDBClusterSnapshotIdentifier()
+        if (snapshots[i].getDBClusterSnapshotIdentifier().startsWith("washery-scrubbed-")){
+            echo snapshots[i].getDBClusterSnapshotIdentifier()
+        }
     }
 
 }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -87,10 +87,9 @@ def cleanClusterWasherySnapshots(client, snapshotRetainCount){
        }
 
         //Sort washery snapshots based on snapshot create time
-        washerySnapshots.sort{a,b-> b.getSnapshotCreateTime().format('d/M/yyyy HH:mm:ss')<=>a.getSnapshotCreateTime().format('d/M/yyyy HH:mm:ss')}
+        washerySnapshots.sort{a,b-> b.getSnapshotCreateTime().compareTo(a.getSnapshotCreateTime())}
         for (int i = 0; i < washerySnapshots.size(); i++) {
-            echo "${washerySnapshots[i].getDBClusterSnapshotIdentifier()}"
-            echo "${washerySnapshots[i].getSnapshotCreateTime().format('d/M/yyyy HH:mm:ss')}"
+            echo "${washerySnapshots[i].getDBClusterSnapshotIdentifier()} - ${washerySnapshots[i].getSnapshotCreateTime().format('d/M/yyyy HH:mm:ss')}"
         }
     }
 

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -2,6 +2,7 @@
 
 import com.base2.ciinabox.aws.AwsClientBuilder
 import com.amazonaws.services.rds.model.DescribeDBSnapshotsRequest
+import com.amazonaws.services.rds.model.DescribeDBClusterSnapshotsRequest
 
 def call(body) {
     def config = body
@@ -14,11 +15,14 @@ def call(body) {
 
     def client = clientBuilder.rds()
 
-    listWasherySnapshots(client)
+    listInstanceWasherySnapshots(client)
+    listClusterWasherySnapshots(client)
 }
 
 
-def listWasherySnapshots(client){
+def listInstanceWasherySnapshots(client){
+    
+    //RDS Instance
     def request = new DescribeDBSnapshotsRequest()
             .withSnapshotType("manual")
     
@@ -28,4 +32,19 @@ def listWasherySnapshots(client){
     for (int i = 0; i < snapshots.size(); i++) {
         echo "${i}: ${snapshots[i]}}"
     }
+
+}
+
+def listClusterWasherySnapshots(client){
+
+    def request = new DescribeDBClusterSnapshotsRequest()
+            .withSnapshotType("manual")
+    
+    def snapshotsResult = client.describeDBClusterSnapshots(request)
+    def snapshots = snapshotsResult.getDBClusterSnapshots()
+
+    for (int i = 0; i < snapshots.size(); i++) {
+        echo "${i}: ${snapshots[i]}}"
+    }
+
 }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -30,9 +30,8 @@ def listInstanceWasherySnapshots(client){
     def snapshots = snapshotsResult.getDBSnapshots()
 
     if(snapshots.size() > 0) {
-        def sorted_snaps = snapshots.sort{a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
+        def sorted_snaps = snapshots.sort{snap.getSnapshotCreateTime()}
         echo "${sorted_snaps}"
-        echo sorted_snaps
         for (int i = 0; i < sorted_snaps.size(); i++) {
             if (sorted_snaps[i].getDBSnapshotIdentifier().startsWith("washery-scrubbed-")){
                 echo "${sorted_snaps[i]}"

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -34,7 +34,7 @@ def listInstanceWasherySnapshots(client){
         snapshots.sort{a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
         for (int i = 0; i < snapshots.size(); i++) {
             if (snapshots[i].getDBSnapshotIdentifier().startsWith("washery-scrubbed-")){
-                washerySnapshots.add(snapshot[i])
+                washerySnapshots.add(snapshots[i])
             }
         }
     }
@@ -58,7 +58,7 @@ def listClusterWasherySnapshots(client){
        snapshots.sort {a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
         for (int i = 0; i < snapshots.size(); i++) {
             if (snapshots[i].getDBClusterSnapshotIdentifier().startsWith("washery-scrubbed-")){
-                washerySnapshots.add(snapshot[i])
+                washerySnapshots.add(snapshots[i])
             }
         }
     }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -55,7 +55,7 @@ def cleanInstanceWasherySnapshots(client, snapshotRetainCount){
     }
     //Sort washery snapshots based on snapshot create time
     washerySnapshots.sort{a,b-> a.getSnapshotCreateTime().compareTo(b.getSnapshotCreateTime())}
-    def delete = washerySnapshotRestore[snapshotRetainCount..-1]
+    def delete = washerySnapshots[snapshotRetainCount..-1]
     println delete
 
     //Delete snapshot's until only the snapshotRetainCount amount remains
@@ -85,7 +85,7 @@ def cleanClusterWasherySnapshots(client, snapshotRetainCount){
 
     //Sort washery snapshots based on snapshot create time
     washerySnapshots.sort{a,b-> a.getSnapshotCreateTime().compareTo(b.getSnapshotCreateTime())}
-    def delete = washerySnapshotRestore[snapshotRetainCount..-1]
+    def delete = washerySnapshots[snapshotRetainCount..-1]
     println delete
 
     //Delete snapshot's until only the snapshotRetainCount amount remains

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -54,7 +54,7 @@ def cleanInstanceWasherySnapshots(client, snapshotRetainCount){
         }
     }
     //Sort washery snapshots based on snapshot create time
-    washerySnapshots.sort{a,b-> a.getSnapshotCreateTime().compareTo(b.getSnapshotCreateTime())}
+    washerySnapshots.sort{a,b-> b.getSnapshotCreateTime().compareTo(a.getSnapshotCreateTime())}
     def delete = washerySnapshots[snapshotRetainCount..-1]
     println delete
 
@@ -84,7 +84,7 @@ def cleanClusterWasherySnapshots(client, snapshotRetainCount){
     }
 
     //Sort washery snapshots based on snapshot create time
-    washerySnapshots.sort{a,b-> a.getSnapshotCreateTime().compareTo(b.getSnapshotCreateTime())}
+    washerySnapshots.sort{a,b-> b.getSnapshotCreateTime().compareTo(a.getSnapshotCreateTime())}
     def delete = washerySnapshots[snapshotRetainCount..-1]
     println delete
 

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -28,15 +28,21 @@ def listInstanceWasherySnapshots(client){
     
     def snapshotsResult = client.describeDBSnapshots(request)
     def snapshots = snapshotsResult.getDBSnapshots()
+    def washerySnapshots = []
 
     if(snapshots.size() > 0) {
         snapshots.sort{a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
         for (int i = 0; i < snapshots.size(); i++) {
             if (snapshots[i].getDBSnapshotIdentifier().startsWith("washery-scrubbed-")){
-                echo "${snapshots[i]}"
+                washerySnapshots.add(snapshot[i])
+            }
         }
     }
+
+    for (int i = 0; i < washerySnapshots.size(); i++) {
+        echo "${washerySnapshots[i]}"
     }
+
 }
 
 def listClusterWasherySnapshots(client){
@@ -46,13 +52,19 @@ def listClusterWasherySnapshots(client){
     
     def snapshotsResult = client.describeDBClusterSnapshots(request)
     def snapshots = snapshotsResult.getDBClusterSnapshots()
+    def washerySnapshots = []
 
     if(snapshots.size() > 0) {
        snapshots.sort {a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
         for (int i = 0; i < snapshots.size(); i++) {
             if (snapshots[i].getDBClusterSnapshotIdentifier().startsWith("washery-scrubbed-")){
-                echo "${snapshots[i]}"
+                washerySnapshots.add(snapshot[i])
             }
         }
     }
+
+    for (int i = 0; i < washerySnapshots.size(); i++) {
+        echo "${washerySnapshots[i]}"
+    }
+
 }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -7,9 +7,9 @@ def call(body) {
     def config = body
    
     def clientBuilder = new AwsClientBuilder([
-    region: config.region,
-    awsAccountId: config.accountId,
-    role: config.role
+        region: config.region,
+        awsAccountId: config.accountId,
+        role: config.role
     ])  
 
     def client = clientBuilder.rds()
@@ -19,10 +19,13 @@ def call(body) {
 
 
 def listWasherySnapshots(client){
-    def describeDBSnapshotsRequest = new DescribeDBSnapshotsRequest()
+    def request = new DescribeDBSnapshotsRequest()
             .withSnapshotType("manual")
     
-    def val = client.describeDBSnapshots(describeDBSnapshotsRequest)
+    def snapshotsResult = client.describeDBSnapshots(request)
+    def snapshots = snapshotsResult.getDBSnapshots()
 
-    echo val
+    for (int i = 0; i < snapshots.size(); i++) {
+        echo "${i}: ${snapshots[i]}}"
+    }
 }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -32,7 +32,7 @@ def call(body) {
     cleanClusterWasherySnapshots(client, config.snapshotRetainCount)
 }
 
-
+@NonCPS
 def cleanInstanceWasherySnapshots(client, snapshotRetainCount){
     
     //RDS Instance
@@ -68,6 +68,7 @@ def cleanInstanceWasherySnapshots(client, snapshotRetainCount){
 
 }
 
+@NonCPS
 def cleanClusterWasherySnapshots(client, snapshotRetainCount){
 
     //RDS Cluster

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -30,7 +30,9 @@ def listInstanceWasherySnapshots(client){
     def snapshots = snapshotsResult.getDBSnapshots()
 
     if(snapshots.size() > 0) {
-        def sorted_snaps = snapshots.sort {a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
+        def sorted_snaps = snapshots.sort{a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
+        echo "${sorted_snaps}"
+        echo sorted_snaps
         for (int i = 0; i < sorted_snaps.size(); i++) {
             if (sorted_snaps[i].getDBSnapshotIdentifier().startsWith("washery-scrubbed-")){
                 echo "${sorted_snaps[i]}"

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -101,7 +101,7 @@ def cleanClusterWasherySnapshots(client, snapshotRetainCount){
         //Delete snapshot's until only the snapshotRetainCount amount remains
         for (snapshot in delete) {
             snapshot_identifier = snapshot.getDBClusterSnapshotIdentifier()
-            def delete_request = new DeleteDBSnapshotRequest().withDBClusterSnapshotIdentifier(snapshot_identifier)
+            def delete_request = new DeleteDBClusterSnapshotRequest().withDBClusterSnapshotIdentifier(snapshot_identifier)
             def response = client.deleteDBClusterSnapshot(delete_request)
             echo "Deleted Snapshot - ${snapshot_identifier} created on ${current_snapshot.getSnapshotCreateTime()}"
         }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -1,0 +1,28 @@
+
+
+import com.base2.ciinabox.aws.AwsClientBuilder
+import com.amazonaws.services.rds.model.DescribeDBSnapshotsRequest
+
+def call(body) {
+    def config = body
+   
+    def clientBuilder = new AwsClientBuilder([
+    region: config.region,
+    awsAccountId: config.accountId,
+    role: config.role
+    ])  
+
+    def client = clientBuilder.rds()
+
+    listWasherySnapshots(client)
+}
+
+
+def listWasherySnapshots(client){
+    def describeDBSnapshotsRequest = new DescribeDBSnapshotsRequest()
+            .withSnapshotType("manual")
+    
+    def val = client.describeDBSnapshots(describeDBSnapshotsRequest)
+
+    echo val
+}

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -30,8 +30,9 @@ def listInstanceWasherySnapshots(client){
     def snapshots = snapshotsResult.getDBSnapshots()
 
     if(snapshots.size() > 0) {
-        def sorted_snaps = snapshots.sort{snap.getSnapshotCreateTime()}
+        def sorted_snaps = snapshots.sort{it.getSnapshotCreateTime()}
         echo "${sorted_snaps}"
+
         for (int i = 0; i < sorted_snaps.size(); i++) {
             if (sorted_snaps[i].getDBSnapshotIdentifier().startsWith("washery-scrubbed-")){
                 echo "${sorted_snaps[i]}"

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -33,6 +33,8 @@ def listInstanceWasherySnapshots(client){
         sorted_snaps = snapshots.sort{a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
         echo "${sorted_snaps}"
         echo sorted_snaps
+        echo "${snapshots}"
+        echo snaphots
         for (int i = 0; i < sorted_snaps.size(); i++) {
                 echo "${sorted_snaps[i]}"
         }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -16,7 +16,7 @@ def call(body) {
     def client = clientBuilder.rds()
 
     listInstanceWasherySnapshots(client)
-    listClusterWasherySnapshots(client)
+    // listClusterWasherySnapshots(client)
 }
 
 
@@ -30,32 +30,27 @@ def listInstanceWasherySnapshots(client){
     def snapshots = snapshotsResult.getDBSnapshots()
 
     if(snapshots.size() > 0) {
-        def sorted_snaps = snapshots.sort{it.getSnapshotCreateTime()}
-        echo "${sorted_snaps}"
-
-        for (int i = 0; i < sorted_snaps.size(); i++) {
-            if (sorted_snaps[i].getDBSnapshotIdentifier().startsWith("washery-scrubbed-")){
-                echo "${sorted_snaps[i]}"
-            }
+        snapshots.sort {a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
+        for (int i = 0; i < snapshots.size(); i++) {
+                echo "${snapshots[i]}"
         }
     }
-
 }
 
-def listClusterWasherySnapshots(client){
+// def listClusterWasherySnapshots(client){
 
-    def request = new DescribeDBClusterSnapshotsRequest()
-            .withSnapshotType("manual")
+//     def request = new DescribeDBClusterSnapshotsRequest()
+//             .withSnapshotType("manual")
     
-    def snapshotsResult = client.describeDBClusterSnapshots(request)
-    def snapshots = snapshotsResult.getDBClusterSnapshots()
+//     def snapshotsResult = client.describeDBClusterSnapshots(request)
+//     def snapshots = snapshotsResult.getDBClusterSnapshots()
 
-    if(snapshots.size() > 0) {
-        def sorted_snaps = snapshots.sort {a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
-        for (int i = 0; i < sorted_snaps.size(); i++) {
-            if (sorted_snaps[i].getDBClusterSnapshotIdentifier().startsWith("washery-scrubbed-")){
-                echo "${sorted_snaps[i]}"
-            }
-        }
-    }
-}
+//     if(snapshots.size() > 0) {
+//         def sorted_snaps = snapshots.sort {a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
+//         for (int i = 0; i < sorted_snaps.size(); i++) {
+//             if (sorted_snaps[i].getDBClusterSnapshotIdentifier().startsWith("washery-scrubbed-")){
+//                 echo "${sorted_snaps[i]}"
+//             }
+//         }
+//     }
+// }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -9,7 +9,7 @@ washeryCleanSnapshots(
   accountId: env.DEV_ACCOUNT_ID,
   role: env.CIINABOXV2_ROLE, // IAM role to assume
   type: 'rds|dbcluster',
-  dryRun: false|true, // dry run option to test what snapshots will be deleted
+  dryRun: false|true, //  (Optional, defaults to true, dry run option to test what snapshots will be deleted)
   snapshotRetainCount: 3 // The number of washery snapshots to keep stored
 )
 ************************************/
@@ -27,13 +27,13 @@ def call(body) {
         awsAccountId: config.accountId,
         role: config.role
     ])  
-
+    def dryRun =  config.get('dryRun',true)
     def client = clientBuilder.rds()
 
     if (config.type.toLowerCase() == 'rds') {
-        cleanInstanceWasherySnapshots(client, config.snapshotRetainCount, config.dryRun)
+        cleanInstanceWasherySnapshots(client, config.snapshotRetainCount, dryRun)
     } else if (config.type.toLowerCase() == 'dbcluster') {
-        cleanClusterWasherySnapshots(client, config.snapshotRetainCount,  config.dryRun)
+        cleanClusterWasherySnapshots(client, config.snapshotRetainCount,  dryRun)
     } else {
         throw new GroovyRuntimeException("washeryCleanSnapshots() doesn't support type ${config.type}")
     }
@@ -60,7 +60,7 @@ def cleanInstanceWasherySnapshots(client, snapshotRetainCount, dryRun){
     
     //If retain count is less than the size of the total washery snapshots
     if (snapshotRetainCount < washerySnapshots.size()){
-        def keep = snapshots[0..snapshotRetainCount-1]
+        def keep = washerySnapshots[0..snapshotRetainCount-1]
         def delete = washerySnapshots[snapshotRetainCount..-1]
         println "Washery Snapshots to Keep - ${keep}"
         println "Washery snapshots to be Deleted - ${delete}"
@@ -103,7 +103,7 @@ def cleanClusterWasherySnapshots(client, snapshotRetainCount, dryRun){
 
     //If retain count is less than the size of the total washery snapshots
     if (snapshotRetainCount < washerySnapshots.size()){
-        def keep = snapshots[0..snapshotRetainCount-1]
+        def keep = washerySnapshots[0..snapshotRetainCount-1]
         def delete = washerySnapshots[snapshotRetainCount..-1]
         println "Washery Snapshots to Keep - ${keep}"
         println "Washery snapshots to be Deleted - ${delete}"

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -2,7 +2,9 @@
 
 import com.base2.ciinabox.aws.AwsClientBuilder
 import com.amazonaws.services.rds.model.DescribeDBSnapshotsRequest
+import com.amazonaws.services.rds.model.DeleteDBSnapshotRequest
 import com.amazonaws.services.rds.model.DescribeDBClusterSnapshotsRequest
+import com.amazonaws.services.rds.model.DeleteDBClusterSnapshotRequest
 
 def call(body) {
     def config = body
@@ -71,7 +73,7 @@ def listClusterWasherySnapshots(client){
         
         def delete_request = new DeleteDBClusterSnapshotRequest().withDBClusterSnapshotIdentifier(snapshot_identifier)
         def response = client.deleteDBClusterSnapshot(delete_request)
-        
+
         echo response
     }
 }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -31,12 +31,11 @@ def listInstanceWasherySnapshots(client){
 
     if(snapshots.size() > 0) {
         sorted_snaps = snapshots.sort{a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
-        echo "${sorted_snaps}"
-        echo sorted_snaps
-        echo "${snapshots}"
-        echo snaphots
         for (int i = 0; i < sorted_snaps.size(); i++) {
                 echo "${sorted_snaps[i]}"
+        }
+        for (int i = 0; i < snapshots.size(); i++) {
+                echo "${snapshots[i]}"
         }
     }
 }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -67,7 +67,7 @@ def cleanInstanceWasherySnapshots(client, snapshotRetainCount){
             snapshot_identifier = snapshot.getDBSnapshotIdentifier()
             def delete_request = new DeleteDBSnapshotRequest().withDBSnapshotIdentifier(snapshot_identifier)
             def response = client.deleteDBSnapshot(delete_request)
-            echo "Deleted Snapshot - ${snapshot_identifier} created on ${current_snapshot.getSnapshotCreateTime()}"
+            echo "Deleted Snapshot - ${snapshot_identifier} created on ${snapshot.getSnapshotCreateTime()}"
         }
     } else {
         println "Skipping delete as retain count exceeds size of existing snapshots"
@@ -103,7 +103,7 @@ def cleanClusterWasherySnapshots(client, snapshotRetainCount){
             snapshot_identifier = snapshot.getDBClusterSnapshotIdentifier()
             def delete_request = new DeleteDBClusterSnapshotRequest().withDBClusterSnapshotIdentifier(snapshot_identifier)
             def response = client.deleteDBClusterSnapshot(delete_request)
-            echo "Deleted Snapshot - ${snapshot_identifier} created on ${current_snapshot.getSnapshotCreateTime()}"
+            echo "Deleted Snapshot - ${snapshot_identifier} created on ${snapshot.getSnapshotCreateTime()}"
         }
     } else {
         println "Skipping delete as retain count exceeds size of existing snapshots"

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -20,8 +20,6 @@ import com.amazonaws.services.rds.model.DeleteDBClusterSnapshotRequest
 
 def call(body) {
     def config = body
-    def snapshotRetainCount = config.snapshotRetainCount
-
     def clientBuilder = new AwsClientBuilder([
         region: config.region,
         awsAccountId: config.accountId,
@@ -30,9 +28,8 @@ def call(body) {
 
     def client = clientBuilder.rds()
 
-
-    cleanInstanceWasherySnapshots(client)
-    cleanClusterWasherySnapshots(client)
+    cleanInstanceWasherySnapshots(client, config.snapshotRetainCount)
+    cleanClusterWasherySnapshots(client, config.snapshotRetainCount)
 }
 
 

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -29,9 +29,12 @@ def listInstanceWasherySnapshots(client){
     def snapshotsResult = client.describeDBSnapshots(request)
     def snapshots = snapshotsResult.getDBSnapshots()
 
-    for (int i = 0; i < snapshots.size(); i++) {
-        if (snapshots[i].getDBSnapshotIdentifier().startsWith("washery-scrubbed-")){
-            echo snapshots[i].getDBSnapshotIdentifier()
+    if(snapshots.size() > 0) {
+        def sorted_snaps = snapshots.sort {a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
+        for (int i = 0; i < sorted_snaps.size(); i++) {
+            if (sorted_snaps[i].getDBSnapshotIdentifier().startsWith("washery-scrubbed-")){
+                echo "${sorted_snaps[i]}"
+            }
         }
     }
 
@@ -45,10 +48,12 @@ def listClusterWasherySnapshots(client){
     def snapshotsResult = client.describeDBClusterSnapshots(request)
     def snapshots = snapshotsResult.getDBClusterSnapshots()
 
-    for (int i = 0; i < snapshots.size(); i++) {
-        if (snapshots[i].getDBClusterSnapshotIdentifier().startsWith("washery-scrubbed-")){
-            echo snapshots[i].getDBClusterSnapshotIdentifier()
+    if(snapshots.size() > 0) {
+        def sorted_snaps = snapshots.sort {a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
+        for (int i = 0; i < sorted_snaps.size(); i++) {
+            if (sorted_snaps[i].getDBClusterSnapshotIdentifier().startsWith("washery-scrubbed-")){
+                echo "${sorted_snaps[i]}"
+            }
         }
     }
-
 }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -30,10 +30,7 @@ def listInstanceWasherySnapshots(client){
     def snapshots = snapshotsResult.getDBSnapshots()
 
     if(snapshots.size() > 0) {
-        sorted_snaps = snapshots.sort{a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
-        for (int i = 0; i < sorted_snaps.size(); i++) {
-                echo "${sorted_snaps[i]}"
-        }
+        snapshots = snapshots.sort{a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
         for (int i = 0; i < snapshots.size(); i++) {
                 echo "${snapshots[i]}"
         }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -46,7 +46,6 @@ def cleanInstanceWasherySnapshots(client, snapshotRetainCount){
     def snapshotsResult = client.describeDBSnapshots(request)
     def snapshots = snapshotsResult.getDBSnapshots()
     def washerySnapshots = []
-    def delete = []
 
     //Retrieve snapshots prefixed with `washery-scrubbed`
     for (snapshot in snapshots) {
@@ -76,7 +75,6 @@ def cleanClusterWasherySnapshots(client, snapshotRetainCount){
     def snapshotsResult = client.describeDBClusterSnapshots(request)
     def snapshots = snapshotsResult.getDBClusterSnapshots()
     def washerySnapshots = []
-    def delete = []
 
     //Retrieve snapshots prefixed with `washery-scrubbed`
     for (snapshot in snapshots) {

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -87,7 +87,7 @@ def cleanClusterWasherySnapshots(client, snapshotRetainCount){
        }
 
         //Sort washery snapshots based on snapshot create time
-        washerySnapshots.sort{a,b-> b.getSnapshotCreateTime().compareTo(a.getSnapshotCreateTime())}
+        washerySnapshots.sort{a,b-> a.getSnapshotCreateTime().compareTo(b.getSnapshotCreateTime())}
         for (int i = 0; i < washerySnapshots.size(); i++) {
             echo "${washerySnapshots[i].getDBClusterSnapshotIdentifier()} - ${washerySnapshots[i].getSnapshotCreateTime().format('d/M/yyyy HH:mm:ss')}"
         }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -36,13 +36,13 @@ def listInstanceWasherySnapshots(client){
         snapshots.sort{a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
         for (int i = 0; i < snapshots.size(); i++) {
             if (snapshots[i].getDBSnapshotIdentifier().startsWith("washery-scrubbed-")){
-                washerySnapshots.add(snapshots[i])
+                sortedWasherySnapshots.add(snapshots[i])
             }
         }
     }
 
-    for (int i = 0; i < washerySnapshots.size(); i++) {
-        echo "${washerySnapshots[i]}"
+    for (int i = 0; i < sortedWasherySnapshots.size(); i++) {
+        echo "${sortedWasherySnapshots[i]}"
     }
 
 }
@@ -61,7 +61,7 @@ def listClusterWasherySnapshots(client){
        snapshots.sort {a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
        for (int i = 0; i < snapshots.size(); i++) {
             if (snapshots[i].getDBClusterSnapshotIdentifier().startsWith("washery-scrubbed-")){
-                washerySnapshots.add(snapshots[i])
+                sortedWasherySnapshots.add(snapshots[i])
             }
        }
     }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -16,7 +16,7 @@ def call(body) {
     def client = clientBuilder.rds()
 
     listInstanceWasherySnapshots(client)
-    // listClusterWasherySnapshots(client)
+    listClusterWasherySnapshots(client)
 }
 
 
@@ -32,25 +32,27 @@ def listInstanceWasherySnapshots(client){
     if(snapshots.size() > 0) {
         snapshots.sort{a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
         for (int i = 0; i < snapshots.size(); i++) {
+            if (snapshots[i].getDBSnapshotIdentifier().startsWith("washery-scrubbed-")){
                 echo "${snapshots[i]}"
         }
     }
+    }
 }
 
-// def listClusterWasherySnapshots(client){
+def listClusterWasherySnapshots(client){
 
-//     def request = new DescribeDBClusterSnapshotsRequest()
-//             .withSnapshotType("manual")
+    def request = new DescribeDBClusterSnapshotsRequest()
+            .withSnapshotType("manual")
     
-//     def snapshotsResult = client.describeDBClusterSnapshots(request)
-//     def snapshots = snapshotsResult.getDBClusterSnapshots()
+    def snapshotsResult = client.describeDBClusterSnapshots(request)
+    def snapshots = snapshotsResult.getDBClusterSnapshots()
 
-//     if(snapshots.size() > 0) {
-//         def sorted_snaps = snapshots.sort {a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
-//         for (int i = 0; i < sorted_snaps.size(); i++) {
-//             if (sorted_snaps[i].getDBClusterSnapshotIdentifier().startsWith("washery-scrubbed-")){
-//                 echo "${sorted_snaps[i]}"
-//             }
-//         }
-//     }
-// }
+    if(snapshots.size() > 0) {
+       snapshots.sort {a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
+        for (int i = 0; i < snapshots.size(); i++) {
+            if (snapshots[i].getDBClusterSnapshotIdentifier().startsWith("washery-scrubbed-")){
+                echo "${snapshots[i]}"
+            }
+        }
+    }
+}

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -30,9 +30,11 @@ def listInstanceWasherySnapshots(client){
     def snapshots = snapshotsResult.getDBSnapshots()
 
     if(snapshots.size() > 0) {
-        snapshots.sort {a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
-        for (int i = 0; i < snapshots.size(); i++) {
-                echo "${snapshots[i]}"
+        def sorted_snaps = snapshots.sort {a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
+        echo "${sorted_snaps}"
+        echo sorted_snaps
+        for (int i = 0; i < sorted_snaps.size(); i++) {
+                echo "${sorted_snaps[i]}"
         }
     }
 }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -77,7 +77,6 @@ def listClusterWasherySnapshots(client){
         //Send delete request
         def delete_request = new DeleteDBClusterSnapshotRequest().withDBClusterSnapshotIdentifier(snapshot_identifier)
         def response = client.deleteDBClusterSnapshot(delete_request)
-
-        echo response
+        echo "Deleted Snapshot - ${snapshot_identifier}"
     }
 }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -30,7 +30,7 @@ def listInstanceWasherySnapshots(client){
     def snapshots = snapshotsResult.getDBSnapshots()
 
     for (int i = 0; i < snapshots.size(); i++) {
-        echo snapshot[i].getDBSnapshotIdentifier()
+        echo snapshots[i].getDBSnapshotIdentifier()
     }
 
 }
@@ -44,7 +44,7 @@ def listClusterWasherySnapshots(client){
     def snapshots = snapshotsResult.getDBClusterSnapshots()
 
     for (int i = 0; i < snapshots.size(); i++) {
-        echo snapshot[i].getDBClusterSnapshotIdentifier()
+        echo snapshots[i].getDBClusterSnapshotIdentifier()
     }
 
 }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -30,7 +30,7 @@ def listInstanceWasherySnapshots(client){
     def snapshots = snapshotsResult.getDBSnapshots()
 
     for (int i = 0; i < snapshots.size(); i++) {
-        echo "${i}: ${snapshots[i]}}"
+        echo snapshot[i].getDBSnapshotIdentifier()
     }
 
 }
@@ -44,7 +44,7 @@ def listClusterWasherySnapshots(client){
     def snapshots = snapshotsResult.getDBClusterSnapshots()
 
     for (int i = 0; i < snapshots.size(); i++) {
-        echo "${i}: ${snapshots[i]}}"
+        echo snapshot[i].getDBClusterSnapshotIdentifier()
     }
 
 }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -53,21 +53,19 @@ def cleanInstanceWasherySnapshots(client, snapshotRetainCount){
         if (snapshot.getDBSnapshotIdentifier().startsWith("washery-scrubbed-")){
             washerySnapshots.add(snapshot)
         }
-        //Sort washery snapshots based on snapshot create time
-        washerySnapshots.sort{a,b-> a.getSnapshotCreateTime().compareTo(b.getSnapshotCreateTime())}
-        def keep = washerySnapshots[0..snapshotRetainCount]
-        def delete = washerySnapshotRestore[snapshotRetainCount..-1]
-        println keep
-        println delete
     }
+    //Sort washery snapshots based on snapshot create time
+    washerySnapshots.sort{a,b-> a.getSnapshotCreateTime().compareTo(b.getSnapshotCreateTime())}
+    def delete = washerySnapshotRestore[snapshotRetainCount..-1]
+    println delete
 
     //Delete snapshot's until only the snapshotRetainCount amount remains
-    for (snapshot in delete) {
-        snapshot_identifier = snapshot.getDBSnapshotIdentifier()
-        def delete_request = new DeleteDBSnapshotRequest().withDBSnapshotIdentifier(snapshot_identifier)
-        def response = client.deleteDBSnapshot(delete_request)
-        echo "Deleted Snapshot - ${snapshot_identifier} created on ${current_snapshot.getSnapshotCreateTime()}"
-    }
+    // for (snapshot in delete) {
+    //     snapshot_identifier = snapshot.getDBSnapshotIdentifier()
+    //     def delete_request = new DeleteDBSnapshotRequest().withDBSnapshotIdentifier(snapshot_identifier)
+    //     def response = client.deleteDBSnapshot(delete_request)
+    //     echo "Deleted Snapshot - ${snapshot_identifier} created on ${current_snapshot.getSnapshotCreateTime()}"
+    // }
 }
 
 @NonCPS
@@ -85,19 +83,18 @@ def cleanClusterWasherySnapshots(client, snapshotRetainCount){
         if (snapshot.getDBClusterSnapshotIdentifier().startsWith("washery-scrubbed-")){
             washerySnapshots.add(snapshot)
         }
-        //Sort washery snapshots based on snapshot create time
-        washerySnapshots.sort{a,b-> a.getSnapshotCreateTime().compareTo(b.getSnapshotCreateTime())}
-        def keep = washerySnapshots[0..snapshotRetainCount]
-        def delete = washerySnapshotRestore[snapshotRetainCount..-1]
-        println keep
-        println delete
     }
 
+    //Sort washery snapshots based on snapshot create time
+    washerySnapshots.sort{a,b-> a.getSnapshotCreateTime().compareTo(b.getSnapshotCreateTime())}
+    def delete = washerySnapshotRestore[snapshotRetainCount..-1]
+    println delete
+
     //Delete snapshot's until only the snapshotRetainCount amount remains
-    for (snapshot in delete) {
-        snapshot_identifier = snapshot.getDBClusterSnapshotIdentifier()
-        def delete_request = new DeleteDBSnapshotRequest().withDBClusterSnapshotIdentifier(snapshot_identifier)
-        def response = client.deleteDBClusterSnapshot(delete_request)
-        echo "Deleted Snapshot - ${snapshot_identifier} created on ${current_snapshot.getSnapshotCreateTime()}"
-    }
+    // for (snapshot in delete) {
+    //     snapshot_identifier = snapshot.getDBClusterSnapshotIdentifier()
+    //     def delete_request = new DeleteDBSnapshotRequest().withDBClusterSnapshotIdentifier(snapshot_identifier)
+    //     def response = client.deleteDBClusterSnapshot(delete_request)
+    //     echo "Deleted Snapshot - ${snapshot_identifier} created on ${current_snapshot.getSnapshotCreateTime()}"
+    // }
 }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -68,8 +68,10 @@ def listClusterWasherySnapshots(client){
     while (sortedWasherySnapshots.size() > 3){
         current_snapshot = sortedWasherySnapshots.shift()
         snapshot_identifier = current_snapshot.getDBClusterSnapshotIdentifier()
-        def DeleteDBClusterSnapshotRequest delete_request = new DeleteDBClusterSnapshotRequest().withDBClusterSnapshotIdentifier(snapshot_identifier)
-        def DBClusterSnapshot response = client.deleteDBClusterSnapshot(delete_request)
+        
+        def delete_request = new DeleteDBClusterSnapshotRequest().withDBClusterSnapshotIdentifier(snapshot_identifier)
+        def response = client.deleteDBClusterSnapshot(delete_request)
+        
         echo response
     }
 }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -68,9 +68,13 @@ def listClusterWasherySnapshots(client){
 
     //Delete snapshot's until only 3 remain
     while (sortedWasherySnapshots.size() > 3){
-        current_snapshot = sortedWasherySnapshots.shift()
+
+        //Get oldest snapshot and remove it
+        current_snapshot = sortedWasherySnapshots.get(0)
+        sortedWasherySnapshots.remove(0)
         snapshot_identifier = current_snapshot.getDBClusterSnapshotIdentifier()
         
+        //Send delete request
         def delete_request = new DeleteDBClusterSnapshotRequest().withDBClusterSnapshotIdentifier(snapshot_identifier)
         def response = client.deleteDBClusterSnapshot(delete_request)
 

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -63,12 +63,14 @@ def cleanInstanceWasherySnapshots(client, snapshotRetainCount){
         println delete
 
         //Delete snapshot's until only the snapshotRetainCount amount remains
-        // for (snapshot in delete) {
-        //     snapshot_identifier = snapshot.getDBSnapshotIdentifier()
-        //     def delete_request = new DeleteDBSnapshotRequest().withDBSnapshotIdentifier(snapshot_identifier)
-        //     def response = client.deleteDBSnapshot(delete_request)
-        //     echo "Deleted Snapshot - ${snapshot_identifier} created on ${current_snapshot.getSnapshotCreateTime()}"
-        // }
+        for (snapshot in delete) {
+            snapshot_identifier = snapshot.getDBSnapshotIdentifier()
+            def delete_request = new DeleteDBSnapshotRequest().withDBSnapshotIdentifier(snapshot_identifier)
+            def response = client.deleteDBSnapshot(delete_request)
+            echo "Deleted Snapshot - ${snapshot_identifier} created on ${current_snapshot.getSnapshotCreateTime()}"
+        }
+    } else {
+        println "Skipping delete as retain count exceeds size of existing snapshots"
     }
 }
 
@@ -97,11 +99,13 @@ def cleanClusterWasherySnapshots(client, snapshotRetainCount){
         println delete
 
         //Delete snapshot's until only the snapshotRetainCount amount remains
-        // for (snapshot in delete) {
-        //     snapshot_identifier = snapshot.getDBClusterSnapshotIdentifier()
-        //     def delete_request = new DeleteDBSnapshotRequest().withDBClusterSnapshotIdentifier(snapshot_identifier)
-        //     def response = client.deleteDBClusterSnapshot(delete_request)
-        //     echo "Deleted Snapshot - ${snapshot_identifier} created on ${current_snapshot.getSnapshotCreateTime()}"
-        // }
+        for (snapshot in delete) {
+            snapshot_identifier = snapshot.getDBClusterSnapshotIdentifier()
+            def delete_request = new DeleteDBSnapshotRequest().withDBClusterSnapshotIdentifier(snapshot_identifier)
+            def response = client.deleteDBClusterSnapshot(delete_request)
+            echo "Deleted Snapshot - ${snapshot_identifier} created on ${current_snapshot.getSnapshotCreateTime()}"
+        }
+    } else {
+        println "Skipping delete as retain count exceeds size of existing snapshots"
     }
 }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -76,29 +76,35 @@ def cleanClusterWasherySnapshots(client, snapshotRetainCount){
     
     def snapshotsResult = client.describeDBClusterSnapshots(request)
     def snapshots = snapshotsResult.getDBClusterSnapshots()
-    def sortedWasherySnapshots = []
+    def washerySnapshots = []
     
-    //Retrieve snapshots prefixed with `washery-scrubbed` and sort them into a new list
+    //Retrieve snapshots prefixed with `washery-scrubbed`
     if(snapshots.size() > 0) {
-       snapshots.sort {a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
        for (int i = 0; i < snapshots.size(); i++) {
             if (snapshots[i].getDBClusterSnapshotIdentifier().startsWith("washery-scrubbed-")){
-                sortedWasherySnapshots.add(snapshots[i])
+                washerySnapshots.add(snapshots[i])
             }
        }
+
+        //Sort washery snapshots based on snapshot create time
+        washerySnapshots.sort{a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
+        for (int i = 0; i < washerySnapshots.size(); i++) {
+            echo "${washerySnapshots[i]}"
+        }
     }
+
 
     //Delete snapshot's until only the snapshotRetainCount amount remains
-    while (sortedWasherySnapshots.size() > snapshotRetainCount){
+    // while (washerySnapshots.size() > snapshotRetainCount){
 
-        //Get oldest snapshot and remove it
-        current_snapshot = sortedWasherySnapshots.get(0)
-        sortedWasherySnapshots.remove(0)
-        snapshot_identifier = current_snapshot.getDBClusterSnapshotIdentifier()
+    //     //Get oldest snapshot and remove it
+    //     current_snapshot = washerySnapshots.get(0)
+    //     washerySnapshots.remove(0)
+    //     snapshot_identifier = current_snapshot.getDBClusterSnapshotIdentifier()
         
-        //Send delete request
-        def delete_request = new DeleteDBClusterSnapshotRequest().withDBClusterSnapshotIdentifier(snapshot_identifier)
-        def response = client.deleteDBClusterSnapshot(delete_request)
-        echo "Deleted Snapshot - ${snapshot_identifier} created on ${current_snapshot.getSnapshotCreateTime()}"
-    }
+    //     //Send delete request
+    //     def delete_request = new DeleteDBClusterSnapshotRequest().withDBClusterSnapshotIdentifier(snapshot_identifier)
+    //     def response = client.deleteDBClusterSnapshot(delete_request)
+    //     echo "Deleted Snapshot - ${snapshot_identifier} created on ${current_snapshot.getSnapshotCreateTime()}"
+    // }
 }

--- a/vars/washeryCleanSnapshots.groovy
+++ b/vars/washeryCleanSnapshots.groovy
@@ -30,7 +30,7 @@ def listInstanceWasherySnapshots(client){
     def snapshots = snapshotsResult.getDBSnapshots()
 
     if(snapshots.size() > 0) {
-        snapshots = snapshots.sort{a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
+        snapshots.sort{a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
         for (int i = 0; i < snapshots.size(); i++) {
                 echo "${snapshots[i]}"
         }


### PR DESCRIPTION
Added step to remove old washery snapshots from a given AWS account. The parameter `snapshotRetainCount` is used to specify how many washery snapshots to retain in the account. The function removes the washery snapshots by oldest to newest.

**Example workflow:** 

1) First we observe the current state of the RDS snapshots in the account, in the following images we see there are **40** total snapshots in the account with **6** being washery snapshots (these are detected by a prefix match on the string `washery-scrubbed-`).

<img width="898" alt="Screen Shot 2023-01-18 at 3 01 33 pm" src="https://user-images.githubusercontent.com/64295670/213080679-f1849c01-7915-4976-a9d9-8374db1f7fdb.png">

<img width="866" alt="Screen Shot 2023-01-18 at 3 01 26 pm" src="https://user-images.githubusercontent.com/64295670/213080684-9a562d4e-a29b-42c9-a714-72cc5b986bdb.png">

1) The function `washeryCleanSnapshots` is called from the pipeline

<img width="291" alt="Screen Shot 2023-01-18 at 3 02 46 pm" src="https://user-images.githubusercontent.com/64295670/213080767-06bb520d-8256-47ed-8bf8-3e7c0a9c9f41.png">

2) Observe that only 3 `washery-scrubbed` snapshots remain as specified by the `snapshotRetainCount`. Also observe that the only washery snapshots were removed and in order from oldest to newest.

<img width="698" alt="Screen Shot 2023-01-18 at 3 05 00 pm" src="https://user-images.githubusercontent.com/64295670/213081088-74806bb3-ceaa-464f-adf7-183a341e2f81.png">

<img width="896" alt="Screen Shot 2023-01-18 at 3 05 11 pm" src="https://user-images.githubusercontent.com/64295670/213081117-1ceccbee-6691-464a-8ff5-b0e15fa2dc24.png">


