### PR TITLE
changeset credential refresh after an hour

### DIFF
--- a/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
+++ b/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
@@ -145,7 +145,8 @@ class AwsClientBuilder implements Serializable {
 
     def creds = getCredentials()
 
-    echo creds 
+    echo "Orig creds: ${creds.getAWSAccessKeyId()}" 
+
 
     if(creds != null) {
       cb.withCredentials(new AWSStaticCredentialsProvider(creds))
@@ -238,7 +239,7 @@ class AwsClientBuilder implements Serializable {
         stsCreds.getSessionToken()
       )
 
-    echo creds
+    echo "new creds: ${creds.getAWSAccessKeyId()}" 
     return creds
   }
 }

--- a/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
+++ b/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
@@ -145,7 +145,7 @@ class AwsClientBuilder implements Serializable {
 
     def creds = getCredentials()
 
-    echo "Orig creds: ${creds.getAWSAccessKeyId()}" 
+    println "Orig creds: ${creds.getAWSAccessKeyId()}" 
 
 
     if(creds != null) {
@@ -239,7 +239,7 @@ class AwsClientBuilder implements Serializable {
         stsCreds.getSessionToken()
       )
 
-    echo "new creds: ${creds.getAWSAccessKeyId()}" 
+    println "new creds: ${creds.getAWSAccessKeyId()}" 
     return creds
   }
 }

--- a/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
+++ b/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
@@ -20,8 +20,7 @@ import com.amazonaws.services.rds.AmazonRDSClientBuilder
 import com.amazonaws.services.codeartifact.AWSCodeArtifactClientBuilder
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
-import java.util.logging.Logger
-import java.util.logging.Level
+
 class AwsClientBuilder implements Serializable {
   
   def region
@@ -137,8 +136,6 @@ class AwsClientBuilder implements Serializable {
   }
 
   def cloudformation() {
-    
-
     def cb = new AmazonCloudFormationClientBuilder().standard()
       .withClientConfiguration(config())
 
@@ -147,11 +144,7 @@ class AwsClientBuilder implements Serializable {
     }
 
     def creds = getCredentials()
-
-    def logger = Logger.getLogger(getClass().name)
-    logger.log(Level.FINE, "Orig creds: ${creds.getAWSAccessKeyId()}" ) 
-
-
+    this.echo(creds.etAWSAccessKeyId())
     if(creds != null) {
       cb.withCredentials(new AWSStaticCredentialsProvider(creds))
     }
@@ -242,9 +235,7 @@ class AwsClientBuilder implements Serializable {
         stsCreds.getSecretAccessKey(),
         stsCreds.getSessionToken()
       )
-
-    def logger = Logger.getLogger(getClass().name)
-    logger.log(Level.FINE, "New creds: ${creds.getAWSAccessKeyId()}" ) 
+    this.echo(creds.etAWSAccessKeyId())
 
     return creds
   }

--- a/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
+++ b/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
@@ -21,7 +21,7 @@ import com.amazonaws.services.codeartifact.AWSCodeArtifactClientBuilder
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
 import java.util.logging.Logger
-
+import java.util.logging.Level
 class AwsClientBuilder implements Serializable {
   
   def region

--- a/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
+++ b/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
@@ -210,14 +210,12 @@ class AwsClientBuilder implements Serializable {
 
   private def getCredentials() {
     if(env['AWS_SESSION_TOKEN'] != null) {
-      print("Session token exists")
       return new BasicSessionCredentials(
         env['AWS_ACCESS_KEY_ID'],
         env['AWS_SECRET_ACCESS_KEY'],
         env['AWS_SESSION_TOKEN']
       )
     } else if(awsAccountId != null && role != null) {
-      print("Spinning up new")
       def stsCreds = assumeRole()
       return new BasicSessionCredentials(
         stsCreds.getAccessKeyId(),
@@ -229,6 +227,12 @@ class AwsClientBuilder implements Serializable {
     }
   }
 
-
-
+  private def refreshCreds() {
+    def stsCreds = assumeRole()
+    return new BasicSessionCredentials(
+        stsCreds.getAccessKeyId(),
+        stsCreds.getSecretAccessKey(),
+        stsCreds.getSessionToken()
+      )
+  }
 }

--- a/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
+++ b/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
@@ -229,7 +229,7 @@ class AwsClientBuilder implements Serializable {
 
   private def refreshCreds() {
     def stsCreds = assumeRole()
-    return new BasicSessionCredentials(
+    def creds =  new BasicSessionCredentials(
         stsCreds.getAccessKeyId(),
         stsCreds.getSecretAccessKey(),
         stsCreds.getSessionToken()

--- a/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
+++ b/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
@@ -144,6 +144,9 @@ class AwsClientBuilder implements Serializable {
     }
 
     def creds = getCredentials()
+
+    echo creds 
+
     if(creds != null) {
       cb.withCredentials(new AWSStaticCredentialsProvider(creds))
     }
@@ -235,6 +238,7 @@ class AwsClientBuilder implements Serializable {
         stsCreds.getSessionToken()
       )
 
+    echo creds
     return creds
   }
 }

--- a/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
+++ b/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
@@ -183,7 +183,7 @@ class AwsClientBuilder implements Serializable {
     return cb.build()
   }
   
-  private def config() {
+  def config() {
     def clientConfiguration = new ClientConfiguration()
       .withRetryPolicy(new RetryPolicy(
         new SDKDefaultRetryCondition(), 
@@ -227,12 +227,14 @@ class AwsClientBuilder implements Serializable {
     }
   }
 
-  private def refreshCreds() {
+  def getNewCreds() {
     def stsCreds = assumeRole()
     def creds =  new BasicSessionCredentials(
         stsCreds.getAccessKeyId(),
         stsCreds.getSecretAccessKey(),
         stsCreds.getSessionToken()
       )
+
+    return creds
   }
 }

--- a/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
+++ b/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
@@ -144,7 +144,7 @@ class AwsClientBuilder implements Serializable {
     }
 
     def creds = getCredentials()
-    this.echo(creds.etAWSAccessKeyId())
+    this.echo(creds.getAWSAccessKeyId())
     if(creds != null) {
       cb.withCredentials(new AWSStaticCredentialsProvider(creds))
     }
@@ -235,7 +235,7 @@ class AwsClientBuilder implements Serializable {
         stsCreds.getSecretAccessKey(),
         stsCreds.getSessionToken()
       )
-    this.echo(creds.etAWSAccessKeyId())
+    this.echo(creds.getAWSAccessKeyId())
 
     return creds
   }

--- a/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
+++ b/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
@@ -210,12 +210,14 @@ class AwsClientBuilder implements Serializable {
 
   private def getCredentials() {
     if(env['AWS_SESSION_TOKEN'] != null) {
+      print("Session token exists")
       return new BasicSessionCredentials(
         env['AWS_ACCESS_KEY_ID'],
         env['AWS_SECRET_ACCESS_KEY'],
         env['AWS_SESSION_TOKEN']
       )
     } else if(awsAccountId != null && role != null) {
+      print("Spinning up new")
       def stsCreds = assumeRole()
       return new BasicSessionCredentials(
         stsCreds.getAccessKeyId(),
@@ -226,5 +228,7 @@ class AwsClientBuilder implements Serializable {
       return null
     }
   }
+
+
 
 }

--- a/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
+++ b/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
@@ -144,7 +144,6 @@ class AwsClientBuilder implements Serializable {
     }
 
     def creds = getCredentials()
-    this.echo(creds.getAWSAccessKeyId())
     if(creds != null) {
       cb.withCredentials(new AWSStaticCredentialsProvider(creds))
     }
@@ -235,7 +234,6 @@ class AwsClientBuilder implements Serializable {
         stsCreds.getSecretAccessKey(),
         stsCreds.getSessionToken()
       )
-    this.echo(creds.getAWSAccessKeyId())
 
     return creds
   }

--- a/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
+++ b/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
@@ -20,6 +20,7 @@ import com.amazonaws.services.rds.AmazonRDSClientBuilder
 import com.amazonaws.services.codeartifact.AWSCodeArtifactClientBuilder
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
+import java.util.logging.Logger
 
 class AwsClientBuilder implements Serializable {
   
@@ -136,6 +137,8 @@ class AwsClientBuilder implements Serializable {
   }
 
   def cloudformation() {
+    
+
     def cb = new AmazonCloudFormationClientBuilder().standard()
       .withClientConfiguration(config())
 
@@ -145,7 +148,8 @@ class AwsClientBuilder implements Serializable {
 
     def creds = getCredentials()
 
-    println "Orig creds: ${creds.getAWSAccessKeyId()}" 
+    def logger = Logger.getLogger(getClass().name)
+    logger.log(Level.FINE, "Orig creds: ${creds.getAWSAccessKeyId()}" ) 
 
 
     if(creds != null) {
@@ -239,7 +243,9 @@ class AwsClientBuilder implements Serializable {
         stsCreds.getSessionToken()
       )
 
-    println "new creds: ${creds.getAWSAccessKeyId()}" 
+    def logger = Logger.getLogger(getClass().name)
+    logger.log(Level.FINE, "New creds: ${creds.getAWSAccessKeyId()}" ) 
+
     return creds
   }
 }

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -120,7 +120,7 @@ def wait(clientBuilder, stackName, changeSetType, config) {
         count++
         echo "Current Client - ${cfclient} & Current Waiter - ${waiter}"
         // Initialise new client and waiter if count exceeds set timeout value
-        if (count > 1) { //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
+        if (count > 300) { //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
           future = waiter.runAsync(
              new WaiterParameters<>(new DescribeStacksRequest().withStackName(stackName)),
              new NoOpWaiterHandler()
@@ -157,11 +157,6 @@ def updateClient(clientBuilder, cfclient, region){
   
   echo "Updating Client"
 
-  def credentialsProvider = (AWSStaticCredentialsProvider) cfclient.getCredentialsProvider();
-  def currentCredentials = credentialsProvider.getCredentials();
-
-  echo "Current creds ${currentCredentials}"
-
   def cb = new AmazonCloudFormationClientBuilder().standard()
     .withClientConfiguration(clientBuilder.config())
 
@@ -175,14 +170,7 @@ def updateClient(clientBuilder, cfclient, region){
     cb.withCredentials(new AWSStaticCredentialsProvider(creds))
   }
 
-  def newClient = cb.build()
-
-  credentialsProvider = (AWSStaticCredentialsProvider) newClient.getCredentialsProvider();
-  currentCredentials = credentialsProvider.getCredentials();
-
-  echo "New creds ${currentCredentials}"
-
-  return newClient
+  return cb.build()
 
 }
 

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -27,8 +27,6 @@ import com.amazonaws.waiters.NoOpWaiterHandler
 import java.util.concurrent.Future
 import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.services.cloudformation.AmazonCloudFormationClientBuilder
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.services.cloudformation.AmazonCloudFormation;
 
 def call(body) {
   def config = body

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -151,11 +151,10 @@ def wait(clientBuilder, stackName, changeSetType) {
 
 def updateClient(clientBuilder){
   echo "Updating Client"
-  creds = clientBuilder.getCredentials()
+  def creds = clientBuilder.refreshCreds()
   echo "Creds - ${creds}"
-  def cfclient = clientBuilder.cloudformation()
-  echo "Created new client - ${cfclient}"
-  return cfclient
+  clientBuilder.withCredentials(new AWSStaticCredentialsProvider(creds))
+  return clientBuilder.build()
 }
 
 def updateWaiter(cfclient, changeSetType){

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -26,6 +26,7 @@ import com.amazonaws.waiters.WaiterUnrecoverableException
 import com.amazonaws.waiters.NoOpWaiterHandler
 import java.util.concurrent.Future
 import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.services.cloudformation.AmazonCloudFormationClientBuilder
 
 def call(body) {
   def config = body

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -116,7 +116,6 @@ def wait(clientBuilder, stackName, changeSetType, config) {
         echo "waiting for execute changeset to ${changeSetType.toLowerCase()} ..."
         Thread.sleep(10000)
         count++
-        echo "Current Client - ${cfclient} & Current Waiter - ${waiter}"
         // Initialise new client and waiter if count exceeds set timeout value
         if (count > 300) { //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
           future = waiter.runAsync(

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -25,6 +25,7 @@ import com.amazonaws.waiters.WaiterParameters
 import com.amazonaws.waiters.WaiterUnrecoverableException
 import com.amazonaws.waiters.NoOpWaiterHandler
 import java.util.concurrent.Future
+import com.amazonaws.auth.AWSStaticCredentialsProvider
 
 def call(body) {
   def config = body

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -151,8 +151,8 @@ def wait(clientBuilder, stackName, changeSetType) {
 
 def updateClient(clientBuilder){
   echo "Updating Client"
-  creds = clientBuilder.getCreds()
-  echo "Creds- ${creds}"
+  creds = clientBuilder.getCredentials()
+  echo "Creds - ${creds}"
   def cfclient = clientBuilder.cloudformation()
   echo "Created new client - ${cfclient}"
   return cfclient

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -122,7 +122,7 @@ def wait(clientBuilder, stackName, changeSetType) {
              new WaiterParameters<>(new DescribeStacksRequest().withStackName(stackName)),
              new NoOpWaiterHandler()
           )
-          cfclient = updateClient(clientBuilder) 
+          cfclient = updateClient() 
           waiter = updateWaiter(cfclient,changeSetType)
           count = 0
         }
@@ -150,11 +150,21 @@ def wait(clientBuilder, stackName, changeSetType) {
   return true
 }
 
-def updateClient(clientBuilder){
+def updateClient(config){
+  
   echo "Updating Client"
-  def creds = clientBuilder.refreshCreds()
-  echo "Creds - ${creds}"
+
+  def clientBuilder = new AmazonCloudFormationClientBuilder().standard()
+      .withClientConfiguration(AwsClientBuilder.config())
+    
+  clientBuilder.withRegion(config.region)
+
+  def newCreds = AwsClientBuilder.refreshCreds()
+
   clientBuilder.withCredentials(new AWSStaticCredentialsProvider(creds))
+
+  echo "New Creds - ${clientBuilder.getCredentials()}"
+  
   return clientBuilder.build()
 }
 

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -116,7 +116,7 @@ def wait(clientBuilder, stackName, changeSetType) {
         count++
         echo "Current Client - ${cfclient} & Current Waiter - ${waiter}"
         // Initialise new client and waiter if count exceeds set timeout value
-        if (count > 300) { //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
+        if (count > 1) { //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
           future = waiter.runAsync(
              new WaiterParameters<>(new DescribeStacksRequest().withStackName(stackName)),
              new NoOpWaiterHandler()
@@ -151,6 +151,8 @@ def wait(clientBuilder, stackName, changeSetType) {
 
 def updateClient(clientBuilder){
   echo "Updating Client"
+  creds = clientBuilder.getCreds()
+  echo "Creds- ${creds}"
   def cfclient = clientBuilder.cloudformation()
   echo "Created new client - ${cfclient}"
   return cfclient

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -120,7 +120,7 @@ def wait(clientBuilder, stackName, changeSetType, config) {
         count++
         echo "Current Client - ${cfclient} & Current Waiter - ${waiter}"
         // Initialise new client and waiter if count exceeds set timeout value
-        if (count > 300) { //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
+        if (count > 1) { //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
           future = waiter.runAsync(
              new WaiterParameters<>(new DescribeStacksRequest().withStackName(stackName)),
              new NoOpWaiterHandler()

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -118,7 +118,7 @@ def wait(clientBuilder, stackName, changeSetType, config) {
         count++
         echo "Current Client - ${cfclient} & Current Waiter - ${waiter}"
         // Initialise new client and waiter if count exceeds set timeout value
-        if (count > 300) { //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
+        if (count > 1) { //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
           future = waiter.runAsync(
              new WaiterParameters<>(new DescribeStacksRequest().withStackName(stackName)),
              new NoOpWaiterHandler()

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -156,7 +156,7 @@ def updateClient(clientBuilder){
   echo "Updating Client"
 
   def newClientBuilder = new AmazonCloudFormationClientBuilder().standard()
-      .withClientConfiguration(AwsClientBuilder.config())
+      .withClientConfiguration(new AwsClientBuilder.config())
     
   newClientBuilder.withRegion(config.region)
 
@@ -167,6 +167,17 @@ def updateClient(clientBuilder){
   echo "New Creds - ${newClientBuilder.getCredentials()}"
   
   return newClientBuilder.build()
+}
+
+private def config() {
+    def clientConfiguration = new ClientConfiguration()
+      .withRetryPolicy(new RetryPolicy(
+        new SDKDefaultRetryCondition(), 
+        new SDKDefaultBackoffStrategy(), 
+        maxErrorRetry, 
+        true))
+    
+    return clientConfiguration
 }
 
 def updateWaiter(cfclient, changeSetType){

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -118,7 +118,7 @@ def wait(clientBuilder, stackName, changeSetType, config) {
         count++
         echo "Current Client - ${cfclient} & Current Waiter - ${waiter}"
         // Initialise new client and waiter if count exceeds set timeout value
-        if (count > 1) { //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
+        if (count > 300) { //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
           future = waiter.runAsync(
              new WaiterParameters<>(new DescribeStacksRequest().withStackName(stackName)),
              new NoOpWaiterHandler()

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -156,7 +156,7 @@ def updateClient(clientBuilder){
   echo "Updating Client"
 
   def newClientBuilder = new AmazonCloudFormationClientBuilder().standard()
-      .withClientConfiguration(clientBuilder.config())
+      .withClientConfiguration(AwsClientBuilder.config())
     
   newClientBuilder.withRegion(config.region)
 

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -118,12 +118,12 @@ def wait(clientBuilder, stackName, changeSetType, config) {
         count++
         // Initialise new client and waiter if count exceeds set timeout value
         if (count > 300) { //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
+          cfclient = updateClient(clientBuilder, cfclient, config.region) 
+          waiter = updateWaiter(cfclient,changeSetType)
           future = waiter.runAsync(
              new WaiterParameters<>(new DescribeStacksRequest().withStackName(stackName)),
              new NoOpWaiterHandler()
           )
-          cfclient = updateClient(clientBuilder, cfclient, config.region) 
-          waiter = updateWaiter(cfclient,changeSetType)
           count = 0
         }
 

--- a/vars/executeChangeSet.groovy
+++ b/vars/executeChangeSet.groovy
@@ -123,7 +123,7 @@ def wait(clientBuilder, stackName, changeSetType) {
              new WaiterParameters<>(new DescribeStacksRequest().withStackName(stackName)),
              new NoOpWaiterHandler()
           )
-          cfclient = updateClient() 
+          cfclient = updateClient(clientBuilder) 
           waiter = updateWaiter(cfclient,changeSetType)
           count = 0
         }
@@ -151,22 +151,22 @@ def wait(clientBuilder, stackName, changeSetType) {
   return true
 }
 
-def updateClient(config){
+def updateClient(clientBuilder){
   
   echo "Updating Client"
 
-  def clientBuilder = new AmazonCloudFormationClientBuilder().standard()
-      .withClientConfiguration(AwsClientBuilder.config())
+  def newClientBuilder = new AmazonCloudFormationClientBuilder().standard()
+      .withClientConfiguration(clientBuilder.config())
     
-  clientBuilder.withRegion(config.region)
+  newClientBuilder.withRegion(config.region)
 
   def newCreds = AwsClientBuilder.refreshCreds()
 
-  clientBuilder.withCredentials(new AWSStaticCredentialsProvider(creds))
+  newClientBuilder.withCredentials(new AWSStaticCredentialsProvider(creds))
 
-  echo "New Creds - ${clientBuilder.getCredentials()}"
+  echo "New Creds - ${newClientBuilder.getCredentials()}"
   
-  return clientBuilder.build()
+  return newClientBuilder.build()
 }
 
 def updateWaiter(cfclient, changeSetType){


### PR DESCRIPTION
#### Added logic for refreshing cloudformation credentials when deployment exceeds 1 hour

1. New client and waiter are created after 50 mins, future is also recreated **AFTER** client is created.

```groovy
if (count > 300) { //3000 seconds = 50 minutes, thread sleep is 10 secs so 300 iterations
          cfclient = updateClient(clientBuilder, cfclient, config.region) 
          waiter = updateWaiter(cfclient,changeSetType)
          future = waiter.runAsync(
             new WaiterParameters<>(new DescribeStacksRequest().withStackName(stackName)),
             new NoOpWaiterHandler()
          )
          count = 0
}
```

#### Added fix for RDS client expiring when cloudformation deployment takes longer than an hour

1. RDS Client is now initialised after changeset deploy completes to avoid creds expiring within that timeframe.
```groovy
//Execute washery restore before rds client is initialised incase duration of changeset exceeds token duration
    changeSetDeploy(
        description: "Scheduled Washery DB Restore of snapshot ${config.snapshot}",
        region: config.region, 
        stackName: config.stackName,
        awsAccountId: config.accountId,
        role: config.role,
        parameters: [ 
            "${config.snapshotParameterName}" : snapshotArn
        ],
        approveChanges: autoApproveChangeSet,
        nestedStacks: true
    )

    client = clientBuilder.rds()
```