### PR TITLE
Feature/lookup snapshot fix

### DIFF
--- a/vars/lookupSnapshot.groovy
+++ b/vars/lookupSnapshot.groovy
@@ -60,13 +60,13 @@ def call(body) {
 
 @NonCPS
 def getAllDBSnapshots(client, request) {
-    List<DBSnapshot> allSnapshots = []
-    String marker = null
+    def allSnapshots = []
+    def marker = null
 
     while (true) {
         request.setMarker(marker)
-        DescribeDBSnapshotsResult snapshotsResult = client.describeDBSnapshots(request)
-        List<DBSnapshot> snapshots = snapshotsResult.getDBSnapshots()
+        def snapshotsResult = client.describeDBSnapshots(request)
+        def snapshots = snapshotsResult.getDBSnapshots()
 
         allSnapshots.addAll(snapshots)
 
@@ -81,13 +81,13 @@ def getAllDBSnapshots(client, request) {
 
 @NonCPS
 def getAllDBClusterSnapshots(client, request) {
-    List<DBClusterSnapshot> allSnapshots = []
-    String marker = null
+    def allSnapshots = []
+    def marker = null
 
     while (true) {
         request.setMarker(marker)
-        DescribeDBClusterSnapshotsResult snapshotsResult = client.describeDBClusterSnapshots(request)
-        List<DBClusterSnapshot> snapshots = snapshotsResult.getDBClusterSnapshots()
+        def snapshotsResult = client.describeDBClusterSnapshots(request)
+        def snapshots = snapshotsResult.getDBClusterSnapshots()
         allSnapshots.addAll(snapshots)
         marker = snapshotsResult.getMarker()
         if (marker == null) {
@@ -108,7 +108,7 @@ def handleDBCluster(client, config) {
         request.setSnapshotType(config.snapshotType)
     }
 
-    List<DBClusterSnapshot> allSnapshots = getAllDBClusterSnapshots(client, request)
+    def allSnapshots = getAllDBClusterSnapshots(client, request)
 
     if (allSnapshots.size() > 0) {
         if (sortBy.toLowerCase() == 'latest') {
@@ -134,7 +134,7 @@ def handleRds(client, config) {
         request.setSnapshotType(config.snapshotType)
     }
 
-    List<DBSnapshot> allSnapshots = getAllDBSnapshots(client, request)
+    def allSnapshots = getAllDBSnapshots(client, request)
 
     if (allSnapshots.size() > 0) {
         if (sortBy.toLowerCase() == 'latest') {

--- a/vars/lookupSnapshot.groovy
+++ b/vars/lookupSnapshot.groovy
@@ -68,7 +68,7 @@ def handleDBCluster(client, config) {
     List<DBClusterSnapshot> allSnapshots = []
     String marker = null
 
-    do {
+    while (true) {
         request.setMarker(marker)
         DescribeDBClusterSnapshotsResult snapshotsResult = client.describeDBClusterSnapshots(request)
         List<DBClusterSnapshot> snapshots = snapshotsResult.getDBClusterSnapshots()
@@ -76,7 +76,10 @@ def handleDBCluster(client, config) {
         allSnapshots.addAll(snapshots)
 
         marker = snapshotsResult.getMarker()
-    } while (marker)
+        if (marker == null) {
+            break
+        }
+    }
 
     if (allSnapshots.size() > 0) {
         if (sortBy.toLowerCase() == 'latest') {

--- a/vars/lookupSnapshot.groovy
+++ b/vars/lookupSnapshot.groovy
@@ -70,9 +70,12 @@ def handleDBCluster(client, config) {
   def snapshotsResult =  client.describeDBClusterSnapshots(request)
   def snapshots = snapshotsResult.getDBClusterSnapshots()
 
+  echo("Snapshots ${snapshots}")
+
   if(snapshots.size() > 0) {
     if(sortBy.toLowerCase() == 'latest') {
       def sorted_snaps = snapshots.sort {a,b-> b.getSnapshotCreateTime()<=>a.getSnapshotCreateTime()}
+      echo("Sorted Snapshots ${sorted_snaps}")
       env[outputName] = sorted_snaps.get(0).getDBClusterSnapshotIdentifier()
       env["${outputName}_ARN"] = sorted_snaps.get(0).getSourceDBClusterSnapshotArn()
       echo("Latest DBCluster snapshot found for ${config.resource} is ${sorted_snaps.get(0).getDBClusterSnapshotIdentifier()} created on ${sorted_snaps.get(0).getSnapshotCreateTime().format('d/M/yyyy HH:mm:ss')}")

--- a/vars/lookupSnapshot.groovy
+++ b/vars/lookupSnapshot.groovy
@@ -24,6 +24,8 @@ import com.amazonaws.services.redshift.model.SnapshotAttributeToSortBy
 
 import com.amazonaws.services.rds.model.DescribeDBSnapshotsRequest
 import com.amazonaws.services.rds.model.DescribeDBClusterSnapshotsRequest
+import com.amazonaws.services.rds.model.DescribeDBClusterSnapshotsResult
+import com.amazonaws.services.rds.model.DBClusterSnapshot
 
 import com.base2.ciinabox.aws.AwsClientBuilder
 

--- a/vars/lookupSnapshot.groovy
+++ b/vars/lookupSnapshot.groovy
@@ -74,14 +74,14 @@ def handleDBCluster(client, config) {
         request.setMarker(marker)
         DescribeDBClusterSnapshotsResult snapshotsResult = client.describeDBClusterSnapshots(request)
         List<DBClusterSnapshot> snapshots = snapshotsResult.getDBClusterSnapshots()
-
         allSnapshots.addAll(snapshots)
-
         marker = snapshotsResult.getMarker()
         if (marker == null) {
             break
         }
     }
+
+    echo("Snapshots: ${allSnapshots}")
 
     if (allSnapshots.size() > 0) {
         if (sortBy.toLowerCase() == 'latest') {


### PR DESCRIPTION
Added fix for `lookupSnapshot` function not returning the latest snapshot intermittently. The issue was that the request would only return the latest 100 snapshots and if more existed they would be omitted. Solution was to add pagination to the requests for RDS Cluster snapshots. Latest snapshot now returns as expected.

Note -  Also added the logic for RDS Instance handling.
