### PR TITLE
Add FAILED state to while loop

### DIFF
--- a/vars/runInspector.groovy
+++ b/vars/runInspector.groovy
@@ -189,7 +189,7 @@ def main(body, stackName, bucketName, fileName, runId) {
 
     // Wait for the inspector test to run
     def runStatus = getRunStatus(assessmentArn)
-    while  (runStatus != "COMPLETED") {
+    while ((runStatus != "COMPLETED") & (runStatus != "FAILED")) {
         runStatus = getRunStatus(assessmentArn)
         println("Test Run Status: ${runStatus}")
         TimeUnit.SECONDS.sleep(60);


### PR DESCRIPTION
This is so that the loop exits when inspector fails, and so it will then look up the results and output them even if it failed. Ideally the pipeline will then fail at the `onFail` condition later in the code.