### PR TITLE
Feature/get asg desired capacity

### DIFF
--- a/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
+++ b/src/com/base2/ciinabox/aws/AwsClientBuilder.groovy
@@ -20,6 +20,7 @@ import com.amazonaws.services.rds.AmazonRDSClientBuilder
 import com.amazonaws.services.codeartifact.AWSCodeArtifactClientBuilder
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
+import com.amazonaws.services.autoscaling.AmazonAutoScalingClientBuilder
 
 class AwsClientBuilder implements Serializable {
   
@@ -183,6 +184,23 @@ class AwsClientBuilder implements Serializable {
     return cb.build()
   }
   
+  def asg() {
+    def cb = new AmazonAutoScalingClientBuilder().standard()
+      .withClientConfiguration(config())
+
+    if (region) {
+      cb.withRegion(region)
+    }
+
+    def creds = getCredentials()
+    if(creds != null) {
+      cb.withCredentials(new AWSStaticCredentialsProvider(creds))
+    }
+
+    return cb.build()
+  
+  }
+
   def config() {
     def clientConfiguration = new ClientConfiguration()
       .withRetryPolicy(new RetryPolicy(

--- a/vars/getAsgDesiredCapacity.groovy
+++ b/vars/getAsgDesiredCapacity.groovy
@@ -9,7 +9,7 @@ example usage
     region: env.AWS_REGION,
     accountId: env.DEV_ACCOUNT_ID,
     role: 'ciinabox-v2',
-    default_count: '5'
+    default_capacity: '5'
   )
 
 ************************************/
@@ -38,7 +38,7 @@ def getDesiredCapacity(client, config) {
     def asgResult = client.describeAutoScalingGroups(request)
     def asgs = asgResult.getAutoScalingGroups()
     if (asgs.isEmpty()) {
-        return config.default_count
+        return config.default_capacity
     } else {
         return asgs.first().getDesiredCapacity()
     }

--- a/vars/getAsgDesiredCapacity.groovy
+++ b/vars/getAsgDesiredCapacity.groovy
@@ -25,17 +25,17 @@ def call(body) {
         role: config.role
     ])  
     def client = clientBuilder.asg()
-    def desired_count = getDesiredCount(client, config)
-    print(desired_count)
-    return desired_count
+    def desired_capacity = getDesiredCapacity(client, config)
+    print(desired_capacity)
+    return desired_capacity
 }
 
 
 @NonCPS
-def getDesiredCount(client, config) {
+def getDesiredCapacity(client, config) {
     def request = new DescribeAutoScalingGroupsRequest()
             .withAutoScalingGroupNames(config.autoscalingGroupName)
 
-    def response = client.describeAutoScalingGroups(request)[0].desiredCapacity
+    def response = client.describeAutoScalingGroups(request).first().getDesiredCapacity()
     print(response)
 }

--- a/vars/getAsgDesiredCapacity.groovy
+++ b/vars/getAsgDesiredCapacity.groovy
@@ -36,9 +36,13 @@ def getDesiredCapacity(client, config) {
     def request = new DescribeAutoScalingGroupsRequest()
             .withAutoScalingGroupNames(config.autoscalingGroupName)
 
-    def asgs = client.describeAutoScalingGroups(request).getAutoScalingGroups()
+    def asgResult = client.describeAutoScalingGroups(request)
+    print(asgResult)
+    def asgs = asgResult.getAutoScalingGroups()
     print(asgs)
-    def desired_capacity = asgs.first().getDesiredCapacity()
-    print(desired_capacity)
-    return desired_capacity
+    if (asgs.isEmpty()) {
+        throw new GroovyRuntimeException("Nothing found for asg: ${config.autoscalingGroupName}")
+    } else {
+        return asgs.first().getDesiredCapacity()
+    }
 }

--- a/vars/getAsgDesiredCapacity.groovy
+++ b/vars/getAsgDesiredCapacity.groovy
@@ -1,14 +1,14 @@
 /***********************************
-getAsgDesiredCount Function
+getAsgDesiredCapacity Function
 
 Takes in an auto scaling group returns the current desired count.
 
 example usage
-  getAsgDesiredCount (
-    autoscaling_group_name: 'name',
+  getAsgDesiredCapacity (
+    autoscalingGroupName: 'name',
     region: env.AWS_REGION,
     accountId: env.DEV_ACCOUNT_ID,
-    role: 'ciinabox',
+    role: 'ciinabox-v2',
     default_count: '5'
   )
 
@@ -34,9 +34,8 @@ def call(body) {
 @NonCPS
 def getDesiredCount(client, config) {
     def request = new DescribeAutoScalingGroupsRequest()
-            .withAutoScalingGroupNames(config.autoscaling_group_name)
+            .withAutoScalingGroupNames(config.autoscalingGroupName)
 
-    def response = client.describeAutoScalingGroups(request)
+    def response = client.describeAutoScalingGroups(request)[0].desiredCapacity
     print(response)
 }
-

--- a/vars/getAsgDesiredCapacity.groovy
+++ b/vars/getAsgDesiredCapacity.groovy
@@ -30,18 +30,15 @@ def call(body) {
     return desired_capacity
 }
 
-
 @NonCPS
 def getDesiredCapacity(client, config) {
     def request = new DescribeAutoScalingGroupsRequest()
             .withAutoScalingGroupNames(config.autoscalingGroupName)
 
     def asgResult = client.describeAutoScalingGroups(request)
-    print(asgResult)
     def asgs = asgResult.getAutoScalingGroups()
-    print(asgs)
     if (asgs.isEmpty()) {
-        throw new GroovyRuntimeException("Nothing found for asg: ${config.autoscalingGroupName}")
+        return config.default_count
     } else {
         return asgs.first().getDesiredCapacity()
     }

--- a/vars/getAsgDesiredCapacity.groovy
+++ b/vars/getAsgDesiredCapacity.groovy
@@ -36,6 +36,9 @@ def getDesiredCapacity(client, config) {
     def request = new DescribeAutoScalingGroupsRequest()
             .withAutoScalingGroupNames(config.autoscalingGroupName)
 
-    def response = client.describeAutoScalingGroups(request).first().getDesiredCapacity()
-    print(response)
+    def asgs = client.describeAutoScalingGroups(request).getAutoScalingGroups()
+    print(asgs)
+    def desired_capacity = asgs.first().getDesiredCapacity()
+    print(desired_capacity)
+    return desired_capacity
 }

--- a/vars/getAsgDesiredCount.groovy
+++ b/vars/getAsgDesiredCount.groovy
@@ -1,0 +1,42 @@
+/***********************************
+getAsgServiceDesiredCount Function
+
+Takes in an auto scaling group returns the current desired count.
+
+example usage
+  getAsgServiceDesiredCount (
+    asg: my-dev-cluster,
+    region: env.AWS_REGION,
+    accountId: env.DEV_ACCOUNT_ID,
+    role: 'ciinabox',
+    default: '5'
+  )
+
+************************************/
+
+import com.base2.ciinabox.aws.AwsClientBuilder
+import software.amazon.awssdk.services.autoscaling.model.DescribeAutoScalingGroupsRequest
+
+def call(body) {
+    def config = body
+    def clientBuilder = new AwsClientBuilder([
+        region: config.region,
+        awsAccountId: config.accountId,
+        role: config.role
+    ])  
+    def client = clientBuilder.asg()
+    def desired_count = getDesiredCount(client, config)
+    print(desired_count)
+    return desired_count
+}
+
+
+@NonCPS
+def getDesiredCount(client, config) {
+    def request = DescribeAutoScalingGroupsRequest()
+            .withAutoScalingGroupNames(config.asg)
+
+    def response = client.describeAutoScalingGroups(request)
+    print(response)
+}
+

--- a/vars/getAsgDesiredCount.groovy
+++ b/vars/getAsgDesiredCount.groovy
@@ -1,21 +1,22 @@
 /***********************************
-getAsgServiceDesiredCount Function
+getAsgDesiredCount Function
 
 Takes in an auto scaling group returns the current desired count.
 
 example usage
-  getAsgServiceDesiredCount (
-    asg: my-dev-cluster,
+  getAsgDesiredCount (
+    asg_name: autoscaling group name,
     region: env.AWS_REGION,
     accountId: env.DEV_ACCOUNT_ID,
     role: 'ciinabox',
-    default: '5'
+    default_count: '5'
   )
 
 ************************************/
 
 import com.base2.ciinabox.aws.AwsClientBuilder
-import software.amazon.awssdk.services.autoscaling.model.DescribeAutoScalingGroupsRequest
+import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest
+
 
 def call(body) {
     def config = body

--- a/vars/getAsgDesiredCount.groovy
+++ b/vars/getAsgDesiredCount.groovy
@@ -5,7 +5,7 @@ Takes in an auto scaling group returns the current desired count.
 
 example usage
   getAsgDesiredCount (
-    asg_name: autoscaling group name,
+    autoscaling_group_name: 'name',
     region: env.AWS_REGION,
     accountId: env.DEV_ACCOUNT_ID,
     role: 'ciinabox',
@@ -16,7 +16,6 @@ example usage
 
 import com.base2.ciinabox.aws.AwsClientBuilder
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest
-
 
 def call(body) {
     def config = body
@@ -34,8 +33,8 @@ def call(body) {
 
 @NonCPS
 def getDesiredCount(client, config) {
-    def request = DescribeAutoScalingGroupsRequest()
-            .withAutoScalingGroupNames(config.asg)
+    def request = new DescribeAutoScalingGroupsRequest()
+            .withAutoScalingGroupNames(config.autoscaling_group_name)
 
     def response = client.describeAutoScalingGroups(request)
     print(response)


### PR DESCRIPTION
### Changelog
- Added function to return the desired capacity for an auto scaling group
- Added ASG type to AWS Client Builder class


#### Examples.

Using the following jenkins step implementing the new asg call.
```groovy
stage('get asg count') {
      steps {
        getAsgDesiredCapacity (
          autoscalingGroupName: 'test',
          region: env.AWS_REGION,
          accountId: env.DEV_ACCOUNT_ID,
          role: 'bearse/feature/iam/ciinabox-v2',
          default_capacity: '5'
        )
      }
    }
```

**Deployed ASG with a desired capacity of 2**
```
[Pipeline] { (get asg count)
[Pipeline] echo
2
```

**No ASGs deployed (Should use default instead)**
```
[Pipeline] { (get asg count)
[Pipeline] echo
5
```