### PR TITLE
s3 client region header getBucketLocation  - not authorized in all regions 

### DIFF
--- a/src/com/base2/ciinabox/aws/CloudformationStack.groovy
+++ b/src/com/base2/ciinabox/aws/CloudformationStack.groovy
@@ -158,7 +158,7 @@ class CloudformationStack implements Serializable {
   region string that can be used in a client
   **/
   def getBucketRegion(String bucket) {
-    def s3GetRegionClient = new AwsClientBuilder().s3()
+    def s3GetRegionClient = new AwsClientBuilder([region: clientBuilder.region]).s3()
     def bucketRegion = s3GetRegionClient.getBucketLocation(bucket)
 
     if (bucketRegion == '' || bucketRegion == 'US') {


### PR DESCRIPTION
At the time of writing this, the getBucketLocation(bucket), is querying a bucket at the ap-southeast-1 with the default region (us-east-01) and failing with:

`com.amazonaws.services.s3.model.AmazonS3Exception: The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'ap-southeast-1' (Service: Amazon S3; Status Code: 400; Error Code: AuthorizationHeaderMalformed; Request ID: 7MS6DSEXVCGSDAMC; S3 Extended Request ID: W+TtTvGGr631WQusxuCjqbwNqVbMYxOroPzHKGXIMuJZe28Z4mGbWM5wCyr94U1q7kAUoT9ccHw=; Proxy: null), S3 Extended Request ID: W+TtTvGGr631WQusxuCjqbwNqVbMYxOroPzHKGXIMuJZe28Z4mGbWM5wCyr94U1q7kAUoT9ccHw=`

I found a couple of reports in the past that this was a temporary issue, but it has lasted more than 48 hours.

This doesn't affect other regions. Tested sa-east-1, eu-central-1 and us-east-1. 

I've also tried to play with different s3 URLs, by providing a specific region endpoint.

Not sure if this behavior is going to be rolled out to other regions or what. This fix isn't ideal if the stack is not in the same region as the bucket but I'm counting on the header will be accepted. 

Feel free to tune in @tarunmenon95 and @jaredbrook 

