### PR TITLE
test s3 fix

### DIFF
--- a/src/com/base2/ciinabox/aws/CloudformationStack.groovy
+++ b/src/com/base2/ciinabox/aws/CloudformationStack.groovy
@@ -141,7 +141,7 @@ class CloudformationStack implements Serializable {
     def s3Client = new AwsClientBuilder([region: bucketRegion]).s3()
     def template = null
     def templateBodyStream = s3Client.getObject(new GetObjectRequest(s3URI.getBucket(), s3URI.getKey())).getObjectContent()
-    def templateBody = templateBodyStream.text
+    def templateBody = templateBodyStream.getText('UTF-8')
 
     if (s3URI.getKey().endsWith('yaml') || s3URI.getKey().endsWith('yml')) {
       Yaml yaml = new Yaml(new IntrinsicsYamlConstructor())

--- a/src/com/base2/ciinabox/aws/CloudformationStack.groovy
+++ b/src/com/base2/ciinabox/aws/CloudformationStack.groovy
@@ -140,7 +140,8 @@ class CloudformationStack implements Serializable {
 
     def s3Client = new AwsClientBuilder([region: bucketRegion]).s3()
     def template = null
-    def templateBody = s3Client.getObject(new GetObjectRequest(s3URI.getBucket(), s3URI.getKey())).getObjectContent()
+    def templateBodyStream = s3Client.getObject(new GetObjectRequest(s3URI.getBucket(), s3URI.getKey())).getObjectContent()
+    def templateBody = templateBodyStream.text
 
     if (s3URI.getKey().endsWith('yaml') || s3URI.getKey().endsWith('yml')) {
       Yaml yaml = new Yaml(new IntrinsicsYamlConstructor())


### PR DESCRIPTION

Read S3ObjectInputStream as text before parsing JSON/YAML templates.

 Problem
\`getTemplateFromUrl()\` passes the S3ObjectInputStream directly to \`JsonSlurper.parseText()\` which expects a String, causing:
\`\`\`
groovy.lang.MissingMethodException: No signature of method: groovy.json.JsonSlurper.parseText() is applicable for argument types: (com.amazonaws.services.s3.model.S3ObjectInputStream)
\`\`\`

Fix
Read the stream content as text before parsing.

## Testing
Tested with geolake multi-region deployments using createChangeSet with nestedStacks."